### PR TITLE
minor bug fix and eliminate compiler warning

### DIFF
--- a/include/fakeit/MethodMockingContext.hpp
+++ b/include/fakeit/MethodMockingContext.hpp
@@ -10,6 +10,7 @@
 #define MethodMockingContext_h__
 
 #include <functional>
+#include <utility>
 #include <type_traits>
 #include <tuple>
 #include <memory>
@@ -168,9 +169,12 @@ protected:
 			: _impl { new Implementation(stubbingContext) } {
 	}
 
-	//Move ctor for use by derived classes.
-	MethodMockingContext(MethodMockingContext& other)
-			: _impl(other._impl) {
+	MethodMockingContext(MethodMockingContext&) = default;
+
+	//we have to write move ctor by hand since VC 2013 doesn't support defaulted
+	//move constructor and move assignment
+	MethodMockingContext(MethodMockingContext&& other) 
+			: _impl(std::move(other._impl)) {
 	}
 
 	virtual ~MethodMockingContext() {}
@@ -273,11 +277,10 @@ public:
 			: MethodMockingContext<R, arglist...>(stubbingContext) {
 	}
 
-	MockingContext(MockingContext<R, arglist...>&other)
-			: MethodMockingContext<R, arglist...>(other) {
-	}
-	MockingContext(MockingContext<R, arglist...> &&other)
-			: MethodMockingContext<R, arglist...>(other) {
+	MockingContext(MockingContext&) = default;
+
+	MockingContext(MockingContext&& other)
+			: MethodMockingContext<R, arglist...>(std::move(other)) {
 	}
 
 	virtual ~MockingContext() THROWS {
@@ -332,7 +335,7 @@ public:
 };
 
 template<typename ... arglist>
-class MockingContext<void, arglist...> : //
+class MockingContext<void, arglist...> :
 public virtual MethodMockingContext<void, arglist...> {
 
 	MockingContext & operator=(const MockingContext&) = delete;
@@ -345,11 +348,10 @@ public:
 	virtual ~MockingContext() THROWS {
 	}
 
-	MockingContext(MockingContext<void, arglist...>& other)
-			: MethodMockingContext<void, arglist...>(other) {
-	}
-	MockingContext(MockingContext<void, arglist...> && other)
-			: MethodMockingContext<void, arglist...>(other) {
+	MockingContext(MockingContext&) = default;
+
+	MockingContext(MockingContext&& other)
+			: MethodMockingContext<void, arglist...>(std::move(other)) {
 	}
 
 	void operator=(std::function<void(arglist&...)> method) {

--- a/include/fakeit/MockImpl.hpp
+++ b/include/fakeit/MockImpl.hpp
@@ -167,7 +167,6 @@ private:
 		//fake->initializeDataMembersArea();
 		void* unmockedMethodStubPtr = union_cast<void*>(&MockImpl<C, baseclasses...>::unmocked);
 		fake->getVirtualTable().initAll(unmockedMethodStubPtr);
-		int dtorOffset = VTUtils::getDestructorOffset<C>();
 		return reinterpret_cast<C*>(fake);
 	}
 

--- a/include/fakeit/RecordedMethodBody.hpp
+++ b/include/fakeit/RecordedMethodBody.hpp
@@ -58,8 +58,8 @@ class RecordedMethodBody: public virtual MethodInvocationHandler<R, arglist...>,
 
 	MockObject<C>& _mock;
 	R (C::*_vMethod)(arglist...);
-	MethodInfo _method;
 	unsigned int _methodId;
+	MethodInfo _method;
 
 	std::vector<std::shared_ptr<Destructable>>_invocationHandlers;
 	std::vector<std::shared_ptr<Destructable>> _actualInvocations;


### PR DESCRIPTION
minor bug fix including make move constructors really 'move', delete unused variable, member initialisation order problem, style consistency.

override implies virtual, final implies override, so neither two of the three keyword should be in the same line, as you did in most member functions.