### PR TITLE
use traits to avoid template specialization, fix move constructor implementation mistake

### DIFF
--- a/include/fakeit/MethodMockingContext.hpp
+++ b/include/fakeit/MethodMockingContext.hpp
@@ -40,7 +40,7 @@ namespace fakeit {
  * The recorded sequence is: {Return(1), Return(2), Return(2), Throw(e1)}
  */
 template<typename R, typename ... arglist>
-class MethodMockingContext: //
+class MethodMockingContext:
 public Sequence,                // For use in Verify(sequence1,...)... phrases.
 		public ActualInvocationsSource, // For use in Using(source1,souece2,...) and VerifyNoOtherInvocations(source1,souece2...) phrases.
 		public virtual StubbingContext<R, arglist...>, // For use in Fake & When phrases
@@ -209,21 +209,17 @@ protected:
 	/**
 	 * Used only by Verify phrase.
 	 */
-	virtual bool matches(Invocation& invocation) override {
+	bool matches(Invocation& invocation) override {
 		return _impl->matches(invocation);
 	}
 
-	virtual void commit() override {
+	void commit() override {
 		_impl->commit();
 	}
 
 	void setMethodDetails(std::string mockName, std::string methodName) {
 		_impl->setMethodDetails(mockName, methodName);
 	}
-
-//	void setMatchingCriteria(const arglist&... args) {
-//		_impl->setMatchingCriteria(args...);
-//	}
 
 	void setMatchingCriteria(std::function<bool(arglist&...)> predicate) {
 		typename ActualInvocation<arglist...>::Matcher* matcher { new UserDefinedInvocationMatcher<arglist...>(predicate) };
@@ -257,7 +253,7 @@ protected:
 	}
 private:
 
-	typename std::function<R(arglist&...)> getOriginalMethod() override {
+	std::function<R(arglist&...)> getOriginalMethod() override {
 		return _impl->getOriginalMethod();
 	}
 
@@ -265,8 +261,8 @@ private:
 };
 
 template<typename R, typename ... arglist>
-class MockingContext: //
-public MethodMockingContext<R, arglist...> //
+class MockingContext:
+public  MethodMockingContext<R, arglist...>
 {
 	MockingContext & operator=(const MockingContext&) = delete;
 
@@ -318,94 +314,47 @@ public:
 	}
 
 	template<typename U = R>
-	typename std::enable_if<!std::is_reference<U>::value, void>::type operator=(const R& r) {
+	typename std::enable_if<!std::is_reference<U>::value, void>::type operator=(
+			const typename std::conditional<std::is_void<R>::value, int, R>::type& r) {
+		static_assert(!std::is_void<R>::value,
+			"you can't mock return value on method with void return type");
 		auto method = [r](arglist&...) -> R {return r;};
 		MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
 	}
 
 	template<typename U = R>
-	typename std::enable_if<std::is_reference<U>::value, void>::type operator=(const R& r) {
+	typename std::enable_if<std::is_reference<U>::value, void>::type operator=(
+			const typename std::conditional<std::is_void<R>::value, int, R>::type& r) {
+		static_assert(!std::is_void<R>::value,
+			"you can't mock return value on method with void return type");
 		auto method = [&r](arglist&...) -> R {return r;};
 		MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
 	}
 };
 
-template<typename ... arglist>
-class MockingContext<void, arglist...> :
-public MethodMockingContext<void, arglist...> {
-
-	MockingContext & operator=(const MockingContext&) = delete;
-
+class DtorMockingContext : public MethodMockingContext < void > {
 public:
-	MockingContext(typename MethodMockingContext<void, arglist...>::Context* stubbingContext)
-			: MethodMockingContext<void, arglist...>(stubbingContext) {
-	}
 
-	MockingContext(MockingContext&) = default;
+    DtorMockingContext(MethodMockingContext<void>::Context *stubbingContext)
+            : MethodMockingContext<void>(stubbingContext) {
+    }
 
-	MockingContext(MockingContext&& other)
-			: MethodMockingContext<void, arglist...>(std::move(other)) {
-	}
+    DtorMockingContext(DtorMockingContext &other) : MethodMockingContext<void>(other) {
+    }
 
-	void operator=(std::function<void(arglist&...)> method) {
-		MethodMockingContext<void, arglist...>::setMethodBodyByAssignment(method);
-	}
+    DtorMockingContext(DtorMockingContext &&other) : MethodMockingContext<void>(other) {
+    }
 
-	MockingContext<void, arglist...>& setMethodDetails(std::string mockName, std::string methodName) {
-		MethodMockingContext<void, arglist...>::setMethodDetails(mockName, methodName);
-		return *this;
-	}
+    void operator=(std::function<void()> method) {
+        MethodMockingContext<void>::setMethodBodyByAssignment(method);
+    }
 
-	MockingContext<void, arglist...>& Using(const arglist&... args) {
-		MethodMockingContext<void, arglist...>::setMatchingCriteria(args...);
-		return *this;
-	}
+    DtorMockingContext& setMethodDetails(std::string mockName, std::string methodName) {
+        MethodMockingContext<void>::setMethodDetails(mockName, methodName);
+        return *this;
+    }
 
-	template<class ...matcherCreator>
-	MockingContext<void, arglist...>& Using(const matcherCreator& ... matcherCreators) {
-		MethodMockingContext<void, arglist...>::setMatchingCriteria(matcherCreators...);
-		return *this;
-	}
-
-	MockingContext<void, arglist...>& Matching(std::function<bool(arglist&...)> matcher) {
-		MethodMockingContext<void, arglist...>::setMatchingCriteria(matcher);
-		return *this;
-	}
-
-	MockingContext<void, arglist...>& operator()(const arglist&... args) {
-		MethodMockingContext<void, arglist...>::setMatchingCriteria(args...);
-		return *this;
-	}
-
-	MockingContext<void, arglist...>& operator()(std::function<bool(arglist&...)> matcher) {
-		MethodMockingContext<void, arglist...>::setMatchingCriteria(matcher);
-		return *this;
-	}
 };
-
-    class DtorMockingContext : public MethodMockingContext < void > {
-    public:
-
-        DtorMockingContext(MethodMockingContext<void>::Context *stubbingContext)
-                : MethodMockingContext<void>(stubbingContext) {
-        }
-
-        DtorMockingContext(DtorMockingContext &other) : MethodMockingContext<void>(other) {
-        }
-
-        DtorMockingContext(DtorMockingContext &&other) : MethodMockingContext<void>(other) {
-        }
-
-        void operator=(std::function<void()> method) {
-            MethodMockingContext<void>::setMethodBodyByAssignment(method);
-        }
-
-		DtorMockingContext& setMethodDetails(std::string mockName, std::string methodName) {
-			MethodMockingContext<void>::setMethodDetails(mockName, methodName);
-			return *this;
-		}
-
-    };
 
 }
 #endif

--- a/include/fakeit/MethodMockingContext.hpp
+++ b/include/fakeit/MethodMockingContext.hpp
@@ -46,7 +46,6 @@ public Sequence,                // For use in Verify(sequence1,...)... phrases.
 		public virtual StubbingContext<R, arglist...>, // For use in Fake & When phrases
 		public virtual SpyingContext<R, arglist...>, // For use in Spy phrases
 		private Invocation::Matcher {
-
 public:
 
 	struct Context: public Destructable {
@@ -267,7 +266,7 @@ private:
 
 template<typename R, typename ... arglist>
 class MockingContext: //
-public virtual MethodMockingContext<R, arglist...> //
+public MethodMockingContext<R, arglist...> //
 {
 	MockingContext & operator=(const MockingContext&) = delete;
 
@@ -333,7 +332,7 @@ public:
 
 template<typename ... arglist>
 class MockingContext<void, arglist...> :
-public virtual MethodMockingContext<void, arglist...> {
+public MethodMockingContext<void, arglist...> {
 
 	MockingContext & operator=(const MockingContext&) = delete;
 
@@ -384,7 +383,7 @@ public:
 	}
 };
 
-    class DtorMockingContext : public virtual MethodMockingContext < void > {
+    class DtorMockingContext : public MethodMockingContext < void > {
     public:
 
         DtorMockingContext(MethodMockingContext<void>::Context *stubbingContext)

--- a/include/mockutils/gcc/VirtualTable.hpp
+++ b/include/mockutils/gcc/VirtualTable.hpp
@@ -89,7 +89,10 @@ struct VirtualTable {
     void setDtor(void *method) {
         unsigned int index = VTUtils::getDestructorOffset<C>();
         void* dtorPtr = union_cast<void*>(&VirtualTable<C,baseclasses...>::dtor);
+        // replace the non deleting destructor.
+        // for example (c1->~C()) calls the non deleting dtor only
         firstMethod[index] = method;
+        // replace the deleting destructor with a method that calls the non deleting one
         firstMethod[index + 1] = dtorPtr;
     }
 

--- a/include/mockutils/mscpp/VirtualTable.hpp
+++ b/include/mockutils/mscpp/VirtualTable.hpp
@@ -180,6 +180,7 @@ struct VirtualTable {
 		firstMethod[index] = method;
 	}
 
+	// the dtor VC++ must of the format: int dtor(int)
 	unsigned int dtor(int){
 		C * c = (C*)this;
 		C& cRef = *c;
@@ -191,6 +192,11 @@ struct VirtualTable {
 	}
 
 	void setDtor(void *method) {
+		// the dtor VC++ must of the format: int dtor(int).
+		// the method passed by the user is: void dtor().
+		// store the user method in a cookie and put the 
+		// correct format method in the virtual table.
+        // the method stored in the vt will call the method in the cookie when invoked.
 		void* dtorPtr = union_cast<void*>(&VirtualTable<C, baseclasses...>::dtor);
 		unsigned int index = VTUtils::getDestructorOffset<C>();
 		firstMethod[index] = dtorPtr;


### PR DESCRIPTION
No functional change. Just using some template technique to avoid duplicating code.
The `MockingContext` class template is partial specialized for method with `void` return type only to disable the assignment operator, that's quite some duplication we don't want to make. So, by using `std::conditional` and `static_assert`, we can make `operator=` work only for non void return types, at the price of messing up the looking of the function parameter type a little bit. The `int` in `typename std::conditional<is_void<R>::value, int, R>::type&` is just a placeholder, which is quite immaterial. I hope you find this as cleaner than template specialization.

By the way, personally I think it's better to expand tab to 4 space in source code, because github use 8 space to represent tab, which is not very friendly to people who read code directly on the website.