### PR TITLE
Enforce stricter warning policy

### DIFF
--- a/build/makefile
+++ b/build/makefile
@@ -31,14 +31,14 @@ fakeit_test_application_with_coverage: $(subst .cpp,_with_coverage,$(CPP_SRCS))
 %.o: ../tests/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C++ Compiler'
-	g++ -flto -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
+	g++ -flto -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -Wextra -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 
 %_with_coverage: ../tests/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C++ Compiler'
-	g++ --coverage -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"$(@:%_with_coverage=%.d)" -MT"$(@:%_with_coverage=%.d)" -o $(subst _with_coverage,.o,"$@") "$<"
+	g++ --coverage -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -Wextra -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"$(@:%_with_coverage=%.d)" -MT"$(@:%_with_coverage=%.d)" -o $(subst _with_coverage,.o,"$@") "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 

--- a/include/fakeit/ActualInvocationsSource.hpp
+++ b/include/fakeit/ActualInvocationsSource.hpp
@@ -60,7 +60,7 @@ namespace fakeit {
         }
 
     protected:
-        bool shouldInclude(fakeit::Invocation *invocation) const {
+        bool shouldInclude(fakeit::Invocation *) const {
             return true;
         }
 

--- a/include/fakeit/ThrowFalseEventHandler.hpp
+++ b/include/fakeit/ThrowFalseEventHandler.hpp
@@ -8,11 +8,11 @@
 namespace fakeit {
     class ThrowFalseEventHandler : public VerificationEventHandler {
 
-        void handle(const SequenceVerificationEvent &e) override {
+        void handle(const SequenceVerificationEvent &) override {
             throw false;
         }
 
-        void handle(const NoMoreInvocationsVerificationEvent &e) override {
+        void handle(const NoMoreInvocationsVerificationEvent &) override {
             throw false;
         }
     };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 2.8.4)
 include_directories ("../include" "../config/standalone")
 project(tests)
 
-set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -pedantic -O3 -flto -Wl,--allow-multiple-definition")
+set(CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -pedantic -O3 -flto -Wl,--allow-multiple-definition")
 
 file(GLOB SOURCE_FILES *.cpp ../include/mockutils/*.hpp ../include/fakeit/*.hpp ../include/*.hpp)
 

--- a/tests/remove_const_volatile_tests.cpp
+++ b/tests/remove_const_volatile_tests.cpp
@@ -26,20 +26,20 @@ public:
 		) {
 		}
 		struct ConstVolatileFunctions{
-			virtual int func1() const = 0;
-			virtual int func2() volatile = 0;
-			virtual int func3() const volatile = 0;
-			virtual const int func4() = 0;
-			virtual const int func6() const = 0;
-			virtual const int func7() const volatile = 0;
+			virtual int * func1() const = 0;
+			virtual int * func2() volatile = 0;
+			virtual int * func3() const volatile = 0;
+			virtual const int * func4() = 0;
+			virtual const int * func6() const = 0;
+			virtual const int * func7() const volatile = 0;
 
-			virtual void proc1() const = 0;
-			virtual void proc2() volatile = 0;
-			virtual void proc3() const volatile = 0;
-			virtual const void proc4() = 0;
- 			virtual const void proc5() const = 0;
- 			virtual const void proc6() volatile = 0;
- 			virtual const void proc7() const volatile = 0;
+			virtual void * proc1() const = 0;
+			virtual void * proc2() volatile = 0;
+			virtual void * proc3() const volatile = 0;
+			virtual const void * proc4() = 0;
+ 			virtual const void * proc5() const = 0;
+ 			virtual const void * proc6() volatile = 0;
+ 			virtual const void * proc7() const volatile = 0;
 		};
 
 		void TestConstFunctions()


### PR DESCRIPTION
In tests/CMakeLists.txt and build/makefile, I added -Wextra to the compilation flags to enforce stricter standards.  As such, I also made the changes necessary to resolve the new warnings.

include/fakeit/ActualInvocationsSource.hpp: invocation was an unused parameter, so I simply removed the parameter itself, but left the type.

include/fakeit/ThrowFalseEventHandler.hpp:  I made a similar change as the previous.

tests/remove_const_volatile_tests.cpp:  Because the return type was const int, the compiler would simply disregard the constness of the return type.  To achieve the same effect, I changed the return type from being an integer to a pointer to an integer.  To ensure that the constness remained in effect, the const version returned a pointer to a constant integer.  And again, a similar change was conducted for the void methods.