### PR TITLE
Fix some compiler warnings

### DIFF
--- a/include/fakeit/Action.hpp
+++ b/include/fakeit/Action.hpp
@@ -31,12 +31,12 @@ namespace fakeit {
     struct Repeat : public Action<R, arglist...> {
         virtual ~Repeat() = default;
 
-        Repeat(std::function<R(arglist &...)> f) :
-                f(f), times(1) {
+        Repeat(std::function<R(arglist &...)> func) :
+                f(func), times(1) {
         }
 
-        Repeat(std::function<R(arglist &...)> f, long times) :
-                f(f), times(times) {
+        Repeat(std::function<R(arglist &...)> func, long t) :
+                f(func), times(t) {
         }
 
         virtual R invoke(arglist &... args) override {
@@ -58,8 +58,8 @@ namespace fakeit {
 
         virtual ~RepeatForever() = default;
 
-        RepeatForever(std::function<R(arglist &...)> f) :
-                f(f) {
+        RepeatForever(std::function<R(arglist &...)> func) :
+                f(func) {
         }
 
         virtual R invoke(arglist &... args) override {

--- a/include/fakeit/ActualInvocation.hpp
+++ b/include/fakeit/ActualInvocation.hpp
@@ -51,7 +51,7 @@ namespace fakeit {
             return _matcher;
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             std::ostringstream out;
             out << getMethod().name();
             print(out, actualArguments);

--- a/include/fakeit/MethodMockingContext.hpp
+++ b/include/fakeit/MethodMockingContext.hpp
@@ -180,7 +180,7 @@ namespace fakeit {
 
         virtual ~MethodMockingContext() { }
 
-        std::string format() const {
+        std::string format() const override {
             return _impl->format();
         }
 

--- a/include/fakeit/Quantifier.hpp
+++ b/include/fakeit/Quantifier.hpp
@@ -13,8 +13,8 @@
 namespace fakeit {
 
     struct Quantity {
-        Quantity(const int quantity) :
-                quantity(quantity) {
+        Quantity(const int q) :
+                quantity(q) {
         }
 
         const int quantity;
@@ -22,8 +22,8 @@ namespace fakeit {
 
     template<typename R>
     struct Quantifier : public Quantity {
-        Quantifier(const int quantity, const R &value) :
-                Quantity(quantity), value(value) {
+        Quantifier(const int q, const R &val) :
+                Quantity(q), value(val) {
         }
 
         const R &value;
@@ -31,14 +31,14 @@ namespace fakeit {
 
     template<>
     struct Quantifier<void> : public Quantity {
-        explicit Quantifier(const int quantity) :
-                Quantity(quantity) {
+        explicit Quantifier(const int q) :
+                Quantity(q) {
         }
     };
 
     struct QuantifierFunctor : public Quantifier<void> {
-        QuantifierFunctor(const int quantity) :
-                Quantifier<void>(quantity) {
+        QuantifierFunctor(const int q) :
+                Quantifier<void>(q) {
         }
 
         template<typename R>

--- a/include/fakeit/RecordedMethodBody.hpp
+++ b/include/fakeit/RecordedMethodBody.hpp
@@ -152,7 +152,7 @@ namespace fakeit {
             }
         }
 
-        void getActualInvocations(std::unordered_set<Invocation *> &into) const {
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
             for (auto destructablePtr : _actualInvocations) {
                 Invocation &invocation = asActualInvocation(*destructablePtr);
                 into.insert(&invocation);

--- a/include/fakeit/Sequence.hpp
+++ b/include/fakeit/Sequence.hpp
@@ -51,8 +51,8 @@ namespace fakeit {
         const Sequence &s2;
 
     protected:
-        ConcatenatedSequence(const Sequence &s1, const Sequence &s2) :
-                s1(s1), s2(s2) {
+        ConcatenatedSequence(const Sequence &seq1, const Sequence &seq2) :
+                s1(seq1), s2(seq2) {
         }
 
     public:
@@ -91,8 +91,8 @@ namespace fakeit {
         const int times;
 
     protected:
-        RepeatedSequence(const Sequence &s, const int times) :
-                _s(s), times(times) {
+        RepeatedSequence(const Sequence &s, const int t) :
+                _s(s), times(t) {
         }
 
     public:

--- a/include/fakeit/invocation_matchers.hpp
+++ b/include/fakeit/invocation_matchers.hpp
@@ -130,7 +130,7 @@ namespace fakeit {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             return {"( user defined matcher )"};
         }
 
@@ -154,7 +154,7 @@ namespace fakeit {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             return {"( Any arguments )"};
         }
 

--- a/include/fakeit/invocation_matchers.hpp
+++ b/include/fakeit/invocation_matchers.hpp
@@ -120,8 +120,8 @@ namespace fakeit {
     struct UserDefinedInvocationMatcher : public ActualInvocation<arglist...>::Matcher {
         virtual ~UserDefinedInvocationMatcher() = default;
 
-        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> matcher)
-                : matcher{matcher} {
+        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> match)
+                : matcher{match} {
         }
 
         virtual bool matches(ActualInvocation<arglist...> &invocation) override {

--- a/include/mockutils/DynamicProxy.hpp
+++ b/include/mockutils/DynamicProxy.hpp
@@ -57,8 +57,8 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &instance) :
-                instance(instance),
+        DynamicProxy(C &inst) :
+                instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
@@ -156,8 +156,8 @@ namespace fakeit {
         private:
             DATA_TYPE *dataMember;
         public:
-            DataMemeberWrapper(DATA_TYPE *dataMember, const arglist &... initargs) :
-                    dataMember(dataMember) {
+            DataMemeberWrapper(DATA_TYPE *dataMem, const arglist &... initargs) :
+                    dataMember(dataMem) {
                 new(dataMember) DATA_TYPE{initargs ...};
             }
 

--- a/include/mockutils/gcc/VirtualTable.hpp
+++ b/include/mockutils/gcc/VirtualTable.hpp
@@ -56,8 +56,8 @@ namespace fakeit {
             friend struct VirtualTable<C, baseclasses...>;
             void **firstMethod;
 
-            Handle(void **firstMethod) :
-                    firstMethod(firstMethod) {
+            Handle(void **method) :
+                    firstMethod(method) {
             }
 
         public:

--- a/include/mockutils/mscpp/VirtualTable.hpp
+++ b/include/mockutils/mscpp/VirtualTable.hpp
@@ -157,7 +157,7 @@ namespace fakeit {
 
             void **firstMethod;
 
-            Handle(void **firstMethod) : firstMethod(firstMethod) { }
+            Handle(void **method) : firstMethod(method) { }
 
         public:
 


### PR DESCRIPTION
Clang 3.6 and GCC 5.1 have some warnings for "shadow" and "inconsistent-missing-override"