### PR TITLE
Fix some compiler warnings again

### DIFF
--- a/include/fakeit/Action.hpp
+++ b/include/fakeit/Action.hpp
@@ -36,8 +36,8 @@ namespace fakeit {
                 f(func), times(1) {
         }
 
-        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func, long times) :
-                f(func), times(times) {
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func, long t) :
+                f(func), times(t) {
         }
 
         virtual R invoke(typename fakeit::production_arg<arglist>::type... args) override {

--- a/include/mockutils/gcc/VirtualTable.hpp
+++ b/include/mockutils/gcc/VirtualTable.hpp
@@ -143,7 +143,7 @@ namespace fakeit {
             auto array = new void *[size + 2 + numOfCookies]{};
             array += numOfCookies; // skip cookies
             array++; // skip top_offset
-            array[0] = (void *) &typeid(C); // type_info
+            array[0] = const_cast<std::type_info *>(&typeid(C)); // type_info
             array++; // skip type_info ptr
             return array;
         }


### PR DESCRIPTION
Hi there!

I fixed some new compiler warnings again. :-)
We have "-Wcast-qual -Wshadow -Wall -Wextra -Werror" here. Maybe you could enable it for your tests, too?!