### PR TITLE
FIX(DynamicProxy): std::vector assert error in getMethodMock after Reset

### DIFF
--- a/generate_fakeit_single_header.py
+++ b/generate_fakeit_single_header.py
@@ -1,3 +1,6 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
 import io
 import os
 import sys

--- a/generate_fakeit_single_header.py
+++ b/generate_fakeit_single_header.py
@@ -89,8 +89,10 @@ def createFakeitFileText(config):
     return text
 
 def createFakeitFile(config,text):
-    os.makedirs(os.path.join( fakeitPath, 'single_header', config))
-    outputPath = os.path.join( fakeitPath, 'single_header', config, 'fakeit.hpp' )
+    dest_dir = os.path.join( fakeitPath, 'single_header', config)
+    if (not os.path.exists(dest_dir)):
+    	os.makedirs(dest_dir)
+    outputPath = os.path.join( dest_dir, 'fakeit.hpp' )
     out = open( outputPath, 'w' )
     write_line(out, "#pragma once" )
     writeHeaderComment(out, config)

--- a/include/mockutils/DynamicProxy.hpp
+++ b/include/mockutils/DynamicProxy.hpp
@@ -82,6 +82,7 @@ namespace fakeit {
 
         void Reset() {
             _methodMocks = {{}};
+            _methodMocks.resize(VTUtils::getVTSize<C>());
             _members = {};
             _cloneVt.copyFrom(originalVtHandle.restore());
         }

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2015-05-19 22:57:31.984000
+ *  Generated: 2015-08-14 10:21:18.605402
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -30,6 +30,40 @@
 #include <string>
 #include <iosfwd>
 #include <atomic>
+#include <tuple>
+
+
+namespace fakeit {
+
+    template<class C>
+    struct naked_type {
+        typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;
+    };
+
+    template< class T > struct tuple_arg         { typedef T  type; };
+    template< class T > struct tuple_arg < T& >  { typedef T& type; };
+    template< class T > struct tuple_arg < T&& > { typedef T&&  type; };
+
+    template<typename... arglist>
+    using ArgumentsTuple = std::tuple<typename tuple_arg<arglist>::type...>;
+
+    template< class T > struct test_arg         { typedef T& type; };
+    template< class T > struct test_arg< T& >   { typedef T& type; };
+    template< class T > struct test_arg< T&& >  { typedef T& type; };
+
+    template< class T > struct production_arg         { typedef T& type; };
+    template< class T > struct production_arg< T& >   { typedef T& type; };
+    template< class T > struct production_arg< T&& >  { typedef T&&  type; };
+
+    template<typename R, typename... arglist>
+    struct VTableMethodType {
+#if defined (__GNUG__)
+        typedef R(*type)(void *, arglist...);
+#elif defined (_MSC_VER)
+        typedef R(__thiscall *type)(void *, arglist...);
+#endif
+    };
+}
 #include <typeinfo>
 #include <tuple>
 #include <string>
@@ -306,11 +340,13 @@ namespace fakeit {
             virtual std::string format() const = 0;
         };
 
-        ActualInvocation(unsigned int ordinal, MethodInfo &method, const arglist &... args) :
-                Invocation(ordinal, method), _matcher{nullptr}, actualArguments{args...} {
+        ActualInvocation(unsigned int ordinal, MethodInfo &method, const typename fakeit::production_arg<arglist>::type... args) :
+            Invocation(ordinal, method), _matcher{ nullptr }
+            , actualArguments{ std::forward<const typename fakeit::production_arg<arglist>::type>(args)... }
+        {
         }
 
-        const std::tuple<arglist...> &getActualArguments() const {
+        ArgumentsTuple<arglist...> & getActualArguments() {
             return actualArguments;
         }
 
@@ -323,7 +359,7 @@ namespace fakeit {
             return _matcher;
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             std::ostringstream out;
             out << getMethod().name();
             print(out, actualArguments);
@@ -332,7 +368,7 @@ namespace fakeit {
 
     private:
         Matcher *_matcher;
-        std::tuple<arglist...> actualArguments;
+        ArgumentsTuple<arglist...> actualArguments;
     };
 
     template<typename ... arglist>
@@ -453,8 +489,8 @@ namespace fakeit {
         const Sequence &s2;
 
     protected:
-        ConcatenatedSequence(const Sequence &s1, const Sequence &s2) :
-                s1(s1), s2(s2) {
+        ConcatenatedSequence(const Sequence &seq1, const Sequence &seq2) :
+                s1(seq1), s2(seq2) {
         }
 
     public:
@@ -493,8 +529,8 @@ namespace fakeit {
         const int times;
 
     protected:
-        RepeatedSequence(const Sequence &s, const int times) :
-                _s(s), times(times) {
+        RepeatedSequence(const Sequence &s, const int t) :
+                _s(s), times(t) {
         }
 
     public:
@@ -14845,7 +14881,7 @@ namespace fakeit {
 
             void **firstMethod;
 
-            Handle(void **firstMethod) : firstMethod(firstMethod) { }
+            Handle(void **method) : firstMethod(method) { }
 
         public:
 
@@ -15018,8 +15054,8 @@ namespace fakeit {
             friend struct VirtualTable<C, baseclasses...>;
             void **firstMethod;
 
-            Handle(void **firstMethod) :
-                    firstMethod(firstMethod) {
+            Handle(void **method) :
+                    firstMethod(method) {
             }
 
         public:
@@ -15105,7 +15141,7 @@ namespace fakeit {
             auto array = new void *[size + 2 + numOfCookies]{};
             array += numOfCookies;
             array++;
-            array[0] = (void *) &typeid(C);
+            array[0] = const_cast<std::type_info *>(&typeid(C));
             array++;
             return array;
         }
@@ -15123,7 +15159,7 @@ namespace fakeit {
 
     template<typename R, typename ... arglist>
     struct MethodInvocationHandler : public Destructible {
-        virtual R handleMethodInvocation(arglist &... args) = 0;
+        virtual R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) = 0;
     };
 
 }
@@ -15225,6 +15261,9 @@ namespace fakeit {
         void *_vMethod;
     };
 }
+#include <utility>
+
+
 namespace fakeit {
 
     struct InvocationHandlerCollection {
@@ -15255,18 +15294,18 @@ namespace fakeit {
 
     protected:
 
-        R methodProxy(unsigned int id, arglist &... args) {
+        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
                     (MethodInvocationHandler<R, arglist...> *) invocationHandlerCollection->getInvocatoinHandlerPtrById(
                             id);
-            return invocationHandler->handleMethodInvocation(args...);
+            return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
         template<int id>
         R methodProxyX(arglist ... args) {
-            return methodProxy(id, args...);
+            return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
     };
 }
@@ -15307,8 +15346,8 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &instance) :
-                instance(instance),
+        DynamicProxy(C &inst) :
+                instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
@@ -15332,6 +15371,7 @@ namespace fakeit {
 
         void Reset() {
             _methodMocks = {{}};
+            _methodMocks.resize(VTUtils::getVTSize<C>());
             _members = {};
             _cloneVt.copyFrom(originalVtHandle.restore());
         }
@@ -15406,8 +15446,8 @@ namespace fakeit {
         private:
             DATA_TYPE *dataMember;
         public:
-            DataMemeberWrapper(DATA_TYPE *dataMember, const arglist &... initargs) :
-                    dataMember(dataMember) {
+            DataMemeberWrapper(DATA_TYPE *dataMem, const arglist &... initargs) :
+                    dataMember(dataMem) {
                 new(dataMember) DATA_TYPE{initargs ...};
             }
 
@@ -15546,16 +15586,6 @@ namespace fakeit {
 #include <iosfwd>
 #include <type_traits>
 #include <typeinfo>
-#include <type_traits>
-#include <typeinfo>
-
-namespace fakeit {
-
-    template<class C>
-    struct naked_type {
-        typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;
-    };
-}
 
 namespace fakeit {
 
@@ -16036,9 +16066,9 @@ namespace fakeit {
             const std::vector<Destructible *> &_matchers;
         };
 
-        virtual bool matches(const std::tuple<arglist...> &actualArgs) {
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
             MatchingLambda l(_matchers);
-            fakeit::for_each(actualArgs, l);
+            fakeit::for_each(actualArguments, l);
             return l.isMatching();
         }
 
@@ -16080,8 +16110,8 @@ namespace fakeit {
     struct UserDefinedInvocationMatcher : public ActualInvocation<arglist...>::Matcher {
         virtual ~UserDefinedInvocationMatcher() = default;
 
-        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> matcher)
-                : matcher{matcher} {
+        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> match)
+                : matcher{match} {
         }
 
         virtual bool matches(ActualInvocation<arglist...> &invocation) override {
@@ -16090,13 +16120,13 @@ namespace fakeit {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             return {"( user defined matcher )"};
         }
 
     private:
-        virtual bool matches(const std::tuple<arglist...> &actualArgs) {
-            return invoke<arglist...>(matcher, actualArgs);
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
+            return invoke<typename tuple_arg<arglist>::type...>(matcher, actualArguments);
         }
 
         const std::function<bool(arglist &...)> matcher;
@@ -16114,12 +16144,13 @@ namespace fakeit {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             return {"( Any arguments )"};
         }
 
     private:
-        virtual bool matches(const std::tuple<arglist...> &) {
+
+        virtual bool matches(const ArgumentsTuple<arglist...>&) {
             return true;
         }
     };
@@ -16141,10 +16172,10 @@ namespace fakeit {
                     _matcher{matcher}, _invocationHandler{invocationHandler} {
             }
 
-            R handleMethodInvocation(arglist &... args) override {
+            R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
                 Destructible &destructable = *_invocationHandler;
                 MethodInvocationHandler<R, arglist...> &invocationHandler = dynamic_cast<MethodInvocationHandler<R, arglist...> &>(destructable);
-                return invocationHandler.handleMethodInvocation(args...);
+                return invocationHandler.handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
             }
 
             typename ActualInvocation<arglist...>::Matcher &getMatcher() const {
@@ -16223,10 +16254,10 @@ namespace fakeit {
         }
 
 
-        R handleMethodInvocation(arglist &... args) override {
+        R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
             unsigned int ordinal = Invocation::nextInvocationOrdinal();
             MethodInfo &method = this->getMethod();
-            auto actualInvoaction = new ActualInvocation<arglist...>(ordinal, method, args...);
+            auto actualInvoaction = new ActualInvocation<arglist...>(ordinal, method, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
 
 
             std::shared_ptr<Destructible> actualInvoactionDtor{actualInvoaction};
@@ -16237,7 +16268,7 @@ namespace fakeit {
                 actualInvoaction->setActualMatcher(&matcher);
                 _actualInvocations.push_back(actualInvoactionDtor);
                 try {
-                    return invocationHandler->handleMethodInvocation(args...);
+                    return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
                 } catch (NoMoreRecordedActionException &) {
                 }
             }
@@ -16257,7 +16288,7 @@ namespace fakeit {
             }
         }
 
-        void getActualInvocations(std::unordered_set<Invocation *> &into) const {
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
             for (auto destructablePtr : _actualInvocations) {
                 Invocation &invocation = asActualInvocation(*destructablePtr);
                 into.insert(&invocation);
@@ -16282,8 +16313,8 @@ namespace fakeit {
 namespace fakeit {
 
     struct Quantity {
-        Quantity(const int quantity) :
-                quantity(quantity) {
+        Quantity(const int q) :
+                quantity(q) {
         }
 
         const int quantity;
@@ -16291,8 +16322,8 @@ namespace fakeit {
 
     template<typename R>
     struct Quantifier : public Quantity {
-        Quantifier(const int quantity, const R &value) :
-                Quantity(quantity), value(value) {
+        Quantifier(const int q, const R &val) :
+                Quantity(q), value(val) {
         }
 
         const R &value;
@@ -16300,14 +16331,14 @@ namespace fakeit {
 
     template<>
     struct Quantifier<void> : public Quantity {
-        explicit Quantifier(const int quantity) :
-                Quantity(quantity) {
+        explicit Quantifier(const int q) :
+                Quantity(q) {
         }
     };
 
     struct QuantifierFunctor : public Quantifier<void> {
-        QuantifierFunctor(const int quantity) :
-                Quantifier<void>(quantity) {
+        QuantifierFunctor(const int q) :
+                Quantifier<void>(q) {
         }
 
         template<typename R>
@@ -16355,6 +16386,7 @@ namespace fakeit {
 #include <functional>
 #include <atomic>
 #include <tuple>
+#include <type_traits>
 
 
 namespace fakeit {
@@ -16363,24 +16395,24 @@ namespace fakeit {
     struct Action : public Destructible {
         virtual ~Action() = default;
 
-        virtual R invoke(arglist &... args) = 0;
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type... args) = 0;
 
         virtual bool isDone() = 0;
     };
 
     template<typename R, typename ... arglist>
-    struct Repeat : public Action<R, arglist...> {
+    struct Repeat : Action<R, arglist...> {
         virtual ~Repeat() = default;
 
-        Repeat(std::function<R(arglist &...)> f) :
-                f(f), times(1) {
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func), times(1) {
         }
 
-        Repeat(std::function<R(arglist &...)> f, long times) :
-                f(f), times(times) {
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func, long t) :
+                f(func), times(t) {
         }
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(typename fakeit::production_arg<arglist>::type... args) override {
             times--;
             return f(args...);
         }
@@ -16390,7 +16422,7 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> f;
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
         long times;
     };
 
@@ -16399,11 +16431,11 @@ namespace fakeit {
 
         virtual ~RepeatForever() = default;
 
-        RepeatForever(std::function<R(arglist &...)> f) :
-                f(f) {
+        RepeatForever(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func) {
         }
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(typename fakeit::production_arg<arglist>::type... args) override {
             return f(args...);
         }
 
@@ -16412,14 +16444,14 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> f;
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
     };
 
     template<typename R, typename ... arglist>
     struct ReturnDefaultValue : public Action<R, arglist...> {
         virtual ~ReturnDefaultValue() = default;
 
-        virtual R invoke(arglist &...) override {
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type...) override {
             return DefaultValue<R>::value();
         }
 
@@ -16431,11 +16463,11 @@ namespace fakeit {
     template<typename R, typename ... arglist>
     struct ReturnDelegateValue : public Action<R, arglist...> {
 
-        ReturnDelegateValue(std::function<R(arglist &...)> delegate) : _delegate(delegate) { }
+        ReturnDelegateValue(std::function<R(const typename fakeit::test_arg<arglist>::type...)> delegate) : _delegate(delegate) { }
 
         virtual ~ReturnDelegateValue() = default;
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type... args) override {
             return _delegate(args...);
         }
 
@@ -16444,7 +16476,7 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> _delegate;
+        std::function<R(const typename fakeit::test_arg<arglist>::type...)> _delegate;
     };
 
 }
@@ -16460,13 +16492,13 @@ namespace fakeit {
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {
-            return Do([r](const arglist &...) -> R { return r; });
+            return Do([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {
-            return Do([&r](const arglist &...) -> R { return r; });
+            return Do([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         MethodStubbingProgress<R, arglist...> &
@@ -16487,27 +16519,27 @@ namespace fakeit {
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, void>::type
         AlwaysReturn(const R &r) {
-            return AlwaysDo([r](const arglist &...) -> R { return r; });
+            return AlwaysDo([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, void>::type
         AlwaysReturn(const R &r) {
-            return AlwaysDo([&r](const arglist &...) -> R { return r; });
+            return AlwaysDo([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         MethodStubbingProgress<R, arglist...> &
         Return() {
-            return Do([](const arglist &...) -> R { return DefaultValue<R>::value(); });
+            return Do([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
         }
 
         void AlwaysReturn() {
-            return AlwaysDo([](const arglist &...) -> R { return DefaultValue<R>::value(); });
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
         }
 
         template<typename E>
         MethodStubbingProgress<R, arglist...> &Throw(const E &e) {
-            return Do([e](const arglist &...) -> R { throw e; });
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
         }
 
         template<typename E>
@@ -16527,11 +16559,11 @@ namespace fakeit {
 
         template<typename E>
         void AlwaysThrow(const E &e) {
-            return AlwaysDo([e](const arglist &...) -> R { throw e; });
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
         }
 
         virtual MethodStubbingProgress<R, arglist...> &
-        Do(std::function<R(arglist &...)> method) {
+            Do(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             return DoImpl(new Repeat<R, arglist...>(method));
         }
 
@@ -16548,7 +16580,7 @@ namespace fakeit {
             return Do(s, t...);
         }
 
-        virtual void AlwaysDo(std::function<R(arglist &...)> method) {
+        virtual void AlwaysDo(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             DoImpl(new RepeatForever<R, arglist...>(method));
         }
 
@@ -16568,11 +16600,20 @@ namespace fakeit {
         }
 
         MethodStubbingProgress<void, arglist...> &Return() {
-            return Do([](const arglist &...) -> void { return DefaultValue<void>::value(); });
+            auto lambda = [](const typename fakeit::test_arg<arglist>::type...) -> void {
+                return DefaultValue<void>::value();
+            };
+            return Do(lambda);
         }
 
+        virtual MethodStubbingProgress<void, arglist...> &Do(
+            std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
+            return DoImpl(new Repeat<void, arglist...>(method));
+        }
+
+
         void AlwaysReturn() {
-            return AlwaysDo([](const arglist &...) -> void { return DefaultValue<void>::value(); });
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> void { return DefaultValue<void>::value(); });
         }
 
         MethodStubbingProgress<void, arglist...> &
@@ -16583,14 +16624,14 @@ namespace fakeit {
 
         template<typename E>
         MethodStubbingProgress<void, arglist...> &Throw(const E &e) {
-            return Do([e](const arglist &...) -> void { throw e; });
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
         }
 
         template<typename E>
         MethodStubbingProgress<void, arglist...> &
         Throw(const Quantifier<E> &q) {
             const E &value = q.value;
-            auto method = [value](const arglist &...) -> void { throw value; };
+            auto method = [value](const typename fakeit::test_arg<arglist>::type...) -> void { throw value; };
             return DoImpl(new Repeat<void, arglist...>(method, q.quantity));
         }
 
@@ -16603,14 +16644,10 @@ namespace fakeit {
 
         template<typename E>
         void AlwaysThrow(const E e) {
-            return AlwaysDo([e](const arglist &...) -> void { throw e; });
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
         }
 
-        virtual MethodStubbingProgress<void, arglist...> &Do(std::function<void(arglist &...)> method) {
-            return DoImpl(new Repeat<void, arglist...>(method));
-        }
-
-        template<typename F>
+           template<typename F>
         MethodStubbingProgress<void, arglist...> &
         Do(const Quantifier<F> &q) {
             return DoImpl(new Repeat<void, arglist...>(q.value, q.quantity));
@@ -16623,7 +16660,7 @@ namespace fakeit {
             return Do(s, t...);
         }
 
-        virtual void AlwaysDo(std::function<void(arglist &...)> method) {
+        virtual void AlwaysDo(std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
             DoImpl(new RepeatForever<void, arglist...>(method));
         }
 
@@ -16675,7 +16712,7 @@ namespace fakeit {
             append(action);
         }
 
-        R handleMethodInvocation(arglist &... args) override {
+        R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
             std::shared_ptr<Destructible> destructablePtr = _recordedActions.front();
             Destructible &destructable = *destructablePtr;
             Action<R, arglist...> &action = dynamic_cast<Action<R, arglist...> &>(destructable);
@@ -16684,7 +16721,7 @@ namespace fakeit {
                     _recordedActions.erase(_recordedActions.begin());
             };
             Finally onExit(finallyClause);
-            return action.invoke(args...);
+            return action.invoke(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
     private:
@@ -16693,7 +16730,7 @@ namespace fakeit {
 
             virtual ~NoMoreRecordedAction() = default;
 
-            virtual R invoke(arglist &...) override {
+            virtual R invoke(const typename fakeit::production_arg<arglist>::type...) override {
                 throw NoMoreRecordedActionException();
             }
 
@@ -16755,10 +16792,10 @@ namespace fakeit {
 
 
     template<typename R, typename ... arglist>
-    struct SpyingContext : public Xaction {
+    struct SpyingContext : Xaction {
         virtual void appendAction(Action<R, arglist...> *action) = 0;
 
-        virtual typename std::function<R(arglist &...)> getOriginalMethod() = 0;
+        virtual std::function<R(arglist&...)> getOriginalMethod() = 0;
     };
 }
 namespace fakeit {
@@ -16877,7 +16914,7 @@ namespace fakeit {
             virtual ~Context() = default;
 
 
-            virtual std::function<R(arglist &...)> getOriginalMethod() = 0;
+            virtual typename std::function<R(arglist&...)> getOriginalMethod() = 0;
 
             virtual std::string getMethodName() = 0;
 
@@ -16963,7 +17000,7 @@ namespace fakeit {
                 getRecordedActionSequence().AppendDo(action);
             }
 
-            void setMethodBodyByAssignment(std::function<R(arglist &...)> method) {
+            void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
                 appendAction(new RepeatForever<R, arglist...>(method));
                 commit();
             }
@@ -17002,7 +17039,7 @@ namespace fakeit {
 
         virtual ~MethodMockingContext() { }
 
-        std::string format() const {
+        std::string format() const override {
             return _impl->format();
         }
 
@@ -17056,7 +17093,7 @@ namespace fakeit {
             _impl->appendAction(action);
         }
 
-        void setMethodBodyByAssignment(std::function<R(arglist &...)> method) {
+        void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             _impl->setMethodBodyByAssignment(method);
         }
 
@@ -17073,7 +17110,7 @@ namespace fakeit {
 
     private:
 
-        std::function<R(arglist &...)> getOriginalMethod() override {
+        typename std::function<R(arglist&...)> getOriginalMethod() override {
             return _impl->getOriginalMethod();
         }
 
@@ -17134,13 +17171,13 @@ namespace fakeit {
 
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, void>::type operator=(const R &r) {
-            auto method = [r](arglist &...) -> R { return r; };
+            auto method = [r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
             MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, void>::type operator=(const R &r) {
-            auto method = [&r](arglist &...) -> R { return r; };
+            auto method = [&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
             MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
         }
     };
@@ -17225,6 +17262,7 @@ namespace fakeit {
 }
 
 namespace fakeit {
+
 
     template<typename C, typename ... baseclasses>
     class MockImpl : private MockObject<C>, public virtual ActualInvocationsSource {
@@ -17345,12 +17383,6 @@ namespace fakeit {
 
             R (C::*_vMethod)(arglist...);
 
-#if defined (__GNUG__)
-            typedef R(*VTableMethodType)(void *, arglist...);
-#elif defined (_MSC_VER)
-            typedef R(__thiscall *VTableMethodType)(void *, arglist...);
-#endif
-
         public:
             virtual ~MethodMockingContextImpl() = default;
 
@@ -17358,12 +17390,13 @@ namespace fakeit {
                     : MethodMockingContextBase<R, arglist...>(mock), _vMethod(vMethod) {
             }
 
-            virtual std::function<R(arglist &...)> getOriginalMethod() override {
+
+            virtual std::function<R(arglist&...)> getOriginalMethod() override {
                 void *mPtr = MethodMockingContextBase<R, arglist...>::_mock.getOriginalMethod(_vMethod);
                 C * instance = &(MethodMockingContextBase<R, arglist...>::_mock.get());
-                return [=](arglist &... args) -> R {
-                    auto m = union_cast<VTableMethodType>(mPtr);
-                    return m(instance, args...);
+                return [=](arglist&... args) -> R {
+                    auto m = union_cast<typename VTableMethodType<R,arglist...>::type>(mPtr);
+                    return m(instance, std::forward<arglist>(args)...);
                 };
             }
         };
@@ -17747,7 +17780,7 @@ namespace fakeit {
     public:
 
         template<typename R, typename ... arglist>
-        struct MethodProgress : public MethodStubbingProgress<R, arglist...> {
+        struct MethodProgress : MethodStubbingProgress<R, arglist...> {
 
             friend class WhenFunctor;
 
@@ -18597,13 +18630,13 @@ namespace fakeit {
     mock.dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    mock.stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    mock.stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    mock.stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/gtest/fakeit.hpp
+++ b/single_header/gtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2015-05-19 22:57:38.017000
+ *  Generated: 2015-08-14 10:22:54.832439
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -30,6 +30,40 @@
 #include <string>
 #include <iosfwd>
 #include <atomic>
+#include <tuple>
+
+
+namespace fakeit {
+
+    template<class C>
+    struct naked_type {
+        typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;
+    };
+
+    template< class T > struct tuple_arg         { typedef T  type; };
+    template< class T > struct tuple_arg < T& >  { typedef T& type; };
+    template< class T > struct tuple_arg < T&& > { typedef T&&  type; };
+
+    template<typename... arglist>
+    using ArgumentsTuple = std::tuple<typename tuple_arg<arglist>::type...>;
+
+    template< class T > struct test_arg         { typedef T& type; };
+    template< class T > struct test_arg< T& >   { typedef T& type; };
+    template< class T > struct test_arg< T&& >  { typedef T& type; };
+
+    template< class T > struct production_arg         { typedef T& type; };
+    template< class T > struct production_arg< T& >   { typedef T& type; };
+    template< class T > struct production_arg< T&& >  { typedef T&&  type; };
+
+    template<typename R, typename... arglist>
+    struct VTableMethodType {
+#if defined (__GNUG__)
+        typedef R(*type)(void *, arglist...);
+#elif defined (_MSC_VER)
+        typedef R(__thiscall *type)(void *, arglist...);
+#endif
+    };
+}
 #include <typeinfo>
 #include <tuple>
 #include <string>
@@ -306,11 +340,13 @@ namespace fakeit {
             virtual std::string format() const = 0;
         };
 
-        ActualInvocation(unsigned int ordinal, MethodInfo &method, const arglist &... args) :
-                Invocation(ordinal, method), _matcher{nullptr}, actualArguments{args...} {
+        ActualInvocation(unsigned int ordinal, MethodInfo &method, const typename fakeit::production_arg<arglist>::type... args) :
+            Invocation(ordinal, method), _matcher{ nullptr }
+            , actualArguments{ std::forward<const typename fakeit::production_arg<arglist>::type>(args)... }
+        {
         }
 
-        const std::tuple<arglist...> &getActualArguments() const {
+        ArgumentsTuple<arglist...> & getActualArguments() {
             return actualArguments;
         }
 
@@ -323,7 +359,7 @@ namespace fakeit {
             return _matcher;
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             std::ostringstream out;
             out << getMethod().name();
             print(out, actualArguments);
@@ -332,7 +368,7 @@ namespace fakeit {
 
     private:
         Matcher *_matcher;
-        std::tuple<arglist...> actualArguments;
+        ArgumentsTuple<arglist...> actualArguments;
     };
 
     template<typename ... arglist>
@@ -453,8 +489,8 @@ namespace fakeit {
         const Sequence &s2;
 
     protected:
-        ConcatenatedSequence(const Sequence &s1, const Sequence &s2) :
-                s1(s1), s2(s2) {
+        ConcatenatedSequence(const Sequence &seq1, const Sequence &seq2) :
+                s1(seq1), s2(seq2) {
         }
 
     public:
@@ -493,8 +529,8 @@ namespace fakeit {
         const int times;
 
     protected:
-        RepeatedSequence(const Sequence &s, const int times) :
-                _s(s), times(times) {
+        RepeatedSequence(const Sequence &s, const int t) :
+                _s(s), times(t) {
         }
 
     public:
@@ -5333,7 +5369,7 @@ namespace fakeit {
 
             void **firstMethod;
 
-            Handle(void **firstMethod) : firstMethod(firstMethod) { }
+            Handle(void **method) : firstMethod(method) { }
 
         public:
 
@@ -5506,8 +5542,8 @@ namespace fakeit {
             friend struct VirtualTable<C, baseclasses...>;
             void **firstMethod;
 
-            Handle(void **firstMethod) :
-                    firstMethod(firstMethod) {
+            Handle(void **method) :
+                    firstMethod(method) {
             }
 
         public:
@@ -5593,7 +5629,7 @@ namespace fakeit {
             auto array = new void *[size + 2 + numOfCookies]{};
             array += numOfCookies;
             array++;
-            array[0] = (void *) &typeid(C);
+            array[0] = const_cast<std::type_info *>(&typeid(C));
             array++;
             return array;
         }
@@ -5611,7 +5647,7 @@ namespace fakeit {
 
     template<typename R, typename ... arglist>
     struct MethodInvocationHandler : public Destructible {
-        virtual R handleMethodInvocation(arglist &... args) = 0;
+        virtual R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) = 0;
     };
 
 }
@@ -5713,6 +5749,9 @@ namespace fakeit {
         void *_vMethod;
     };
 }
+#include <utility>
+
+
 namespace fakeit {
 
     struct InvocationHandlerCollection {
@@ -5743,18 +5782,18 @@ namespace fakeit {
 
     protected:
 
-        R methodProxy(unsigned int id, arglist &... args) {
+        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
                     (MethodInvocationHandler<R, arglist...> *) invocationHandlerCollection->getInvocatoinHandlerPtrById(
                             id);
-            return invocationHandler->handleMethodInvocation(args...);
+            return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
         template<int id>
         R methodProxyX(arglist ... args) {
-            return methodProxy(id, args...);
+            return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
     };
 }
@@ -5795,8 +5834,8 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &instance) :
-                instance(instance),
+        DynamicProxy(C &inst) :
+                instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
@@ -5820,6 +5859,7 @@ namespace fakeit {
 
         void Reset() {
             _methodMocks = {{}};
+            _methodMocks.resize(VTUtils::getVTSize<C>());
             _members = {};
             _cloneVt.copyFrom(originalVtHandle.restore());
         }
@@ -5894,8 +5934,8 @@ namespace fakeit {
         private:
             DATA_TYPE *dataMember;
         public:
-            DataMemeberWrapper(DATA_TYPE *dataMember, const arglist &... initargs) :
-                    dataMember(dataMember) {
+            DataMemeberWrapper(DATA_TYPE *dataMem, const arglist &... initargs) :
+                    dataMember(dataMem) {
                 new(dataMember) DATA_TYPE{initargs ...};
             }
 
@@ -6034,16 +6074,6 @@ namespace fakeit {
 #include <iosfwd>
 #include <type_traits>
 #include <typeinfo>
-#include <type_traits>
-#include <typeinfo>
-
-namespace fakeit {
-
-    template<class C>
-    struct naked_type {
-        typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;
-    };
-}
 
 namespace fakeit {
 
@@ -6524,9 +6554,9 @@ namespace fakeit {
             const std::vector<Destructible *> &_matchers;
         };
 
-        virtual bool matches(const std::tuple<arglist...> &actualArgs) {
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
             MatchingLambda l(_matchers);
-            fakeit::for_each(actualArgs, l);
+            fakeit::for_each(actualArguments, l);
             return l.isMatching();
         }
 
@@ -6568,8 +6598,8 @@ namespace fakeit {
     struct UserDefinedInvocationMatcher : public ActualInvocation<arglist...>::Matcher {
         virtual ~UserDefinedInvocationMatcher() = default;
 
-        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> matcher)
-                : matcher{matcher} {
+        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> match)
+                : matcher{match} {
         }
 
         virtual bool matches(ActualInvocation<arglist...> &invocation) override {
@@ -6578,13 +6608,13 @@ namespace fakeit {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             return {"( user defined matcher )"};
         }
 
     private:
-        virtual bool matches(const std::tuple<arglist...> &actualArgs) {
-            return invoke<arglist...>(matcher, actualArgs);
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
+            return invoke<typename tuple_arg<arglist>::type...>(matcher, actualArguments);
         }
 
         const std::function<bool(arglist &...)> matcher;
@@ -6602,12 +6632,13 @@ namespace fakeit {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             return {"( Any arguments )"};
         }
 
     private:
-        virtual bool matches(const std::tuple<arglist...> &) {
+
+        virtual bool matches(const ArgumentsTuple<arglist...>&) {
             return true;
         }
     };
@@ -6629,10 +6660,10 @@ namespace fakeit {
                     _matcher{matcher}, _invocationHandler{invocationHandler} {
             }
 
-            R handleMethodInvocation(arglist &... args) override {
+            R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
                 Destructible &destructable = *_invocationHandler;
                 MethodInvocationHandler<R, arglist...> &invocationHandler = dynamic_cast<MethodInvocationHandler<R, arglist...> &>(destructable);
-                return invocationHandler.handleMethodInvocation(args...);
+                return invocationHandler.handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
             }
 
             typename ActualInvocation<arglist...>::Matcher &getMatcher() const {
@@ -6711,10 +6742,10 @@ namespace fakeit {
         }
 
 
-        R handleMethodInvocation(arglist &... args) override {
+        R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
             unsigned int ordinal = Invocation::nextInvocationOrdinal();
             MethodInfo &method = this->getMethod();
-            auto actualInvoaction = new ActualInvocation<arglist...>(ordinal, method, args...);
+            auto actualInvoaction = new ActualInvocation<arglist...>(ordinal, method, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
 
 
             std::shared_ptr<Destructible> actualInvoactionDtor{actualInvoaction};
@@ -6725,7 +6756,7 @@ namespace fakeit {
                 actualInvoaction->setActualMatcher(&matcher);
                 _actualInvocations.push_back(actualInvoactionDtor);
                 try {
-                    return invocationHandler->handleMethodInvocation(args...);
+                    return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
                 } catch (NoMoreRecordedActionException &) {
                 }
             }
@@ -6745,7 +6776,7 @@ namespace fakeit {
             }
         }
 
-        void getActualInvocations(std::unordered_set<Invocation *> &into) const {
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
             for (auto destructablePtr : _actualInvocations) {
                 Invocation &invocation = asActualInvocation(*destructablePtr);
                 into.insert(&invocation);
@@ -6770,8 +6801,8 @@ namespace fakeit {
 namespace fakeit {
 
     struct Quantity {
-        Quantity(const int quantity) :
-                quantity(quantity) {
+        Quantity(const int q) :
+                quantity(q) {
         }
 
         const int quantity;
@@ -6779,8 +6810,8 @@ namespace fakeit {
 
     template<typename R>
     struct Quantifier : public Quantity {
-        Quantifier(const int quantity, const R &value) :
-                Quantity(quantity), value(value) {
+        Quantifier(const int q, const R &val) :
+                Quantity(q), value(val) {
         }
 
         const R &value;
@@ -6788,14 +6819,14 @@ namespace fakeit {
 
     template<>
     struct Quantifier<void> : public Quantity {
-        explicit Quantifier(const int quantity) :
-                Quantity(quantity) {
+        explicit Quantifier(const int q) :
+                Quantity(q) {
         }
     };
 
     struct QuantifierFunctor : public Quantifier<void> {
-        QuantifierFunctor(const int quantity) :
-                Quantifier<void>(quantity) {
+        QuantifierFunctor(const int q) :
+                Quantifier<void>(q) {
         }
 
         template<typename R>
@@ -6843,6 +6874,7 @@ namespace fakeit {
 #include <functional>
 #include <atomic>
 #include <tuple>
+#include <type_traits>
 
 
 namespace fakeit {
@@ -6851,24 +6883,24 @@ namespace fakeit {
     struct Action : public Destructible {
         virtual ~Action() = default;
 
-        virtual R invoke(arglist &... args) = 0;
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type... args) = 0;
 
         virtual bool isDone() = 0;
     };
 
     template<typename R, typename ... arglist>
-    struct Repeat : public Action<R, arglist...> {
+    struct Repeat : Action<R, arglist...> {
         virtual ~Repeat() = default;
 
-        Repeat(std::function<R(arglist &...)> f) :
-                f(f), times(1) {
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func), times(1) {
         }
 
-        Repeat(std::function<R(arglist &...)> f, long times) :
-                f(f), times(times) {
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func, long t) :
+                f(func), times(t) {
         }
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(typename fakeit::production_arg<arglist>::type... args) override {
             times--;
             return f(args...);
         }
@@ -6878,7 +6910,7 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> f;
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
         long times;
     };
 
@@ -6887,11 +6919,11 @@ namespace fakeit {
 
         virtual ~RepeatForever() = default;
 
-        RepeatForever(std::function<R(arglist &...)> f) :
-                f(f) {
+        RepeatForever(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func) {
         }
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(typename fakeit::production_arg<arglist>::type... args) override {
             return f(args...);
         }
 
@@ -6900,14 +6932,14 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> f;
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
     };
 
     template<typename R, typename ... arglist>
     struct ReturnDefaultValue : public Action<R, arglist...> {
         virtual ~ReturnDefaultValue() = default;
 
-        virtual R invoke(arglist &...) override {
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type...) override {
             return DefaultValue<R>::value();
         }
 
@@ -6919,11 +6951,11 @@ namespace fakeit {
     template<typename R, typename ... arglist>
     struct ReturnDelegateValue : public Action<R, arglist...> {
 
-        ReturnDelegateValue(std::function<R(arglist &...)> delegate) : _delegate(delegate) { }
+        ReturnDelegateValue(std::function<R(const typename fakeit::test_arg<arglist>::type...)> delegate) : _delegate(delegate) { }
 
         virtual ~ReturnDelegateValue() = default;
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type... args) override {
             return _delegate(args...);
         }
 
@@ -6932,7 +6964,7 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> _delegate;
+        std::function<R(const typename fakeit::test_arg<arglist>::type...)> _delegate;
     };
 
 }
@@ -6948,13 +6980,13 @@ namespace fakeit {
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {
-            return Do([r](const arglist &...) -> R { return r; });
+            return Do([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {
-            return Do([&r](const arglist &...) -> R { return r; });
+            return Do([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         MethodStubbingProgress<R, arglist...> &
@@ -6975,27 +7007,27 @@ namespace fakeit {
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, void>::type
         AlwaysReturn(const R &r) {
-            return AlwaysDo([r](const arglist &...) -> R { return r; });
+            return AlwaysDo([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, void>::type
         AlwaysReturn(const R &r) {
-            return AlwaysDo([&r](const arglist &...) -> R { return r; });
+            return AlwaysDo([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         MethodStubbingProgress<R, arglist...> &
         Return() {
-            return Do([](const arglist &...) -> R { return DefaultValue<R>::value(); });
+            return Do([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
         }
 
         void AlwaysReturn() {
-            return AlwaysDo([](const arglist &...) -> R { return DefaultValue<R>::value(); });
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
         }
 
         template<typename E>
         MethodStubbingProgress<R, arglist...> &Throw(const E &e) {
-            return Do([e](const arglist &...) -> R { throw e; });
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
         }
 
         template<typename E>
@@ -7015,11 +7047,11 @@ namespace fakeit {
 
         template<typename E>
         void AlwaysThrow(const E &e) {
-            return AlwaysDo([e](const arglist &...) -> R { throw e; });
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
         }
 
         virtual MethodStubbingProgress<R, arglist...> &
-        Do(std::function<R(arglist &...)> method) {
+            Do(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             return DoImpl(new Repeat<R, arglist...>(method));
         }
 
@@ -7036,7 +7068,7 @@ namespace fakeit {
             return Do(s, t...);
         }
 
-        virtual void AlwaysDo(std::function<R(arglist &...)> method) {
+        virtual void AlwaysDo(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             DoImpl(new RepeatForever<R, arglist...>(method));
         }
 
@@ -7056,11 +7088,20 @@ namespace fakeit {
         }
 
         MethodStubbingProgress<void, arglist...> &Return() {
-            return Do([](const arglist &...) -> void { return DefaultValue<void>::value(); });
+            auto lambda = [](const typename fakeit::test_arg<arglist>::type...) -> void {
+                return DefaultValue<void>::value();
+            };
+            return Do(lambda);
         }
 
+        virtual MethodStubbingProgress<void, arglist...> &Do(
+            std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
+            return DoImpl(new Repeat<void, arglist...>(method));
+        }
+
+
         void AlwaysReturn() {
-            return AlwaysDo([](const arglist &...) -> void { return DefaultValue<void>::value(); });
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> void { return DefaultValue<void>::value(); });
         }
 
         MethodStubbingProgress<void, arglist...> &
@@ -7071,14 +7112,14 @@ namespace fakeit {
 
         template<typename E>
         MethodStubbingProgress<void, arglist...> &Throw(const E &e) {
-            return Do([e](const arglist &...) -> void { throw e; });
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
         }
 
         template<typename E>
         MethodStubbingProgress<void, arglist...> &
         Throw(const Quantifier<E> &q) {
             const E &value = q.value;
-            auto method = [value](const arglist &...) -> void { throw value; };
+            auto method = [value](const typename fakeit::test_arg<arglist>::type...) -> void { throw value; };
             return DoImpl(new Repeat<void, arglist...>(method, q.quantity));
         }
 
@@ -7091,14 +7132,10 @@ namespace fakeit {
 
         template<typename E>
         void AlwaysThrow(const E e) {
-            return AlwaysDo([e](const arglist &...) -> void { throw e; });
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
         }
 
-        virtual MethodStubbingProgress<void, arglist...> &Do(std::function<void(arglist &...)> method) {
-            return DoImpl(new Repeat<void, arglist...>(method));
-        }
-
-        template<typename F>
+           template<typename F>
         MethodStubbingProgress<void, arglist...> &
         Do(const Quantifier<F> &q) {
             return DoImpl(new Repeat<void, arglist...>(q.value, q.quantity));
@@ -7111,7 +7148,7 @@ namespace fakeit {
             return Do(s, t...);
         }
 
-        virtual void AlwaysDo(std::function<void(arglist &...)> method) {
+        virtual void AlwaysDo(std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
             DoImpl(new RepeatForever<void, arglist...>(method));
         }
 
@@ -7163,7 +7200,7 @@ namespace fakeit {
             append(action);
         }
 
-        R handleMethodInvocation(arglist &... args) override {
+        R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
             std::shared_ptr<Destructible> destructablePtr = _recordedActions.front();
             Destructible &destructable = *destructablePtr;
             Action<R, arglist...> &action = dynamic_cast<Action<R, arglist...> &>(destructable);
@@ -7172,7 +7209,7 @@ namespace fakeit {
                     _recordedActions.erase(_recordedActions.begin());
             };
             Finally onExit(finallyClause);
-            return action.invoke(args...);
+            return action.invoke(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
     private:
@@ -7181,7 +7218,7 @@ namespace fakeit {
 
             virtual ~NoMoreRecordedAction() = default;
 
-            virtual R invoke(arglist &...) override {
+            virtual R invoke(const typename fakeit::production_arg<arglist>::type...) override {
                 throw NoMoreRecordedActionException();
             }
 
@@ -7243,10 +7280,10 @@ namespace fakeit {
 
 
     template<typename R, typename ... arglist>
-    struct SpyingContext : public Xaction {
+    struct SpyingContext : Xaction {
         virtual void appendAction(Action<R, arglist...> *action) = 0;
 
-        virtual typename std::function<R(arglist &...)> getOriginalMethod() = 0;
+        virtual std::function<R(arglist&...)> getOriginalMethod() = 0;
     };
 }
 namespace fakeit {
@@ -7365,7 +7402,7 @@ namespace fakeit {
             virtual ~Context() = default;
 
 
-            virtual std::function<R(arglist &...)> getOriginalMethod() = 0;
+            virtual typename std::function<R(arglist&...)> getOriginalMethod() = 0;
 
             virtual std::string getMethodName() = 0;
 
@@ -7451,7 +7488,7 @@ namespace fakeit {
                 getRecordedActionSequence().AppendDo(action);
             }
 
-            void setMethodBodyByAssignment(std::function<R(arglist &...)> method) {
+            void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
                 appendAction(new RepeatForever<R, arglist...>(method));
                 commit();
             }
@@ -7490,7 +7527,7 @@ namespace fakeit {
 
         virtual ~MethodMockingContext() { }
 
-        std::string format() const {
+        std::string format() const override {
             return _impl->format();
         }
 
@@ -7544,7 +7581,7 @@ namespace fakeit {
             _impl->appendAction(action);
         }
 
-        void setMethodBodyByAssignment(std::function<R(arglist &...)> method) {
+        void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             _impl->setMethodBodyByAssignment(method);
         }
 
@@ -7561,7 +7598,7 @@ namespace fakeit {
 
     private:
 
-        std::function<R(arglist &...)> getOriginalMethod() override {
+        typename std::function<R(arglist&...)> getOriginalMethod() override {
             return _impl->getOriginalMethod();
         }
 
@@ -7622,13 +7659,13 @@ namespace fakeit {
 
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, void>::type operator=(const R &r) {
-            auto method = [r](arglist &...) -> R { return r; };
+            auto method = [r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
             MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, void>::type operator=(const R &r) {
-            auto method = [&r](arglist &...) -> R { return r; };
+            auto method = [&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
             MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
         }
     };
@@ -7713,6 +7750,7 @@ namespace fakeit {
 }
 
 namespace fakeit {
+
 
     template<typename C, typename ... baseclasses>
     class MockImpl : private MockObject<C>, public virtual ActualInvocationsSource {
@@ -7833,12 +7871,6 @@ namespace fakeit {
 
             R (C::*_vMethod)(arglist...);
 
-#if defined (__GNUG__)
-            typedef R(*VTableMethodType)(void *, arglist...);
-#elif defined (_MSC_VER)
-            typedef R(__thiscall *VTableMethodType)(void *, arglist...);
-#endif
-
         public:
             virtual ~MethodMockingContextImpl() = default;
 
@@ -7846,12 +7878,13 @@ namespace fakeit {
                     : MethodMockingContextBase<R, arglist...>(mock), _vMethod(vMethod) {
             }
 
-            virtual std::function<R(arglist &...)> getOriginalMethod() override {
+
+            virtual std::function<R(arglist&...)> getOriginalMethod() override {
                 void *mPtr = MethodMockingContextBase<R, arglist...>::_mock.getOriginalMethod(_vMethod);
                 C * instance = &(MethodMockingContextBase<R, arglist...>::_mock.get());
-                return [=](arglist &... args) -> R {
-                    auto m = union_cast<VTableMethodType>(mPtr);
-                    return m(instance, args...);
+                return [=](arglist&... args) -> R {
+                    auto m = union_cast<typename VTableMethodType<R,arglist...>::type>(mPtr);
+                    return m(instance, std::forward<arglist>(args)...);
                 };
             }
         };
@@ -8235,7 +8268,7 @@ namespace fakeit {
     public:
 
         template<typename R, typename ... arglist>
-        struct MethodProgress : public MethodStubbingProgress<R, arglist...> {
+        struct MethodProgress : MethodStubbingProgress<R, arglist...> {
 
             friend class WhenFunctor;
 
@@ -9085,13 +9118,13 @@ namespace fakeit {
     mock.dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    mock.stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    mock.stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    mock.stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/mstest/fakeit.hpp
+++ b/single_header/mstest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2015-05-19 22:57:42.436000
+ *  Generated: 2015-08-14 10:22:58.014098
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -30,6 +30,40 @@
 #include <string>
 #include <iosfwd>
 #include <atomic>
+#include <tuple>
+
+
+namespace fakeit {
+
+    template<class C>
+    struct naked_type {
+        typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;
+    };
+
+    template< class T > struct tuple_arg         { typedef T  type; };
+    template< class T > struct tuple_arg < T& >  { typedef T& type; };
+    template< class T > struct tuple_arg < T&& > { typedef T&&  type; };
+
+    template<typename... arglist>
+    using ArgumentsTuple = std::tuple<typename tuple_arg<arglist>::type...>;
+
+    template< class T > struct test_arg         { typedef T& type; };
+    template< class T > struct test_arg< T& >   { typedef T& type; };
+    template< class T > struct test_arg< T&& >  { typedef T& type; };
+
+    template< class T > struct production_arg         { typedef T& type; };
+    template< class T > struct production_arg< T& >   { typedef T& type; };
+    template< class T > struct production_arg< T&& >  { typedef T&&  type; };
+
+    template<typename R, typename... arglist>
+    struct VTableMethodType {
+#if defined (__GNUG__)
+        typedef R(*type)(void *, arglist...);
+#elif defined (_MSC_VER)
+        typedef R(__thiscall *type)(void *, arglist...);
+#endif
+    };
+}
 #include <typeinfo>
 #include <tuple>
 #include <string>
@@ -306,11 +340,13 @@ namespace fakeit {
             virtual std::string format() const = 0;
         };
 
-        ActualInvocation(unsigned int ordinal, MethodInfo &method, const arglist &... args) :
-                Invocation(ordinal, method), _matcher{nullptr}, actualArguments{args...} {
+        ActualInvocation(unsigned int ordinal, MethodInfo &method, const typename fakeit::production_arg<arglist>::type... args) :
+            Invocation(ordinal, method), _matcher{ nullptr }
+            , actualArguments{ std::forward<const typename fakeit::production_arg<arglist>::type>(args)... }
+        {
         }
 
-        const std::tuple<arglist...> &getActualArguments() const {
+        ArgumentsTuple<arglist...> & getActualArguments() {
             return actualArguments;
         }
 
@@ -323,7 +359,7 @@ namespace fakeit {
             return _matcher;
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             std::ostringstream out;
             out << getMethod().name();
             print(out, actualArguments);
@@ -332,7 +368,7 @@ namespace fakeit {
 
     private:
         Matcher *_matcher;
-        std::tuple<arglist...> actualArguments;
+        ArgumentsTuple<arglist...> actualArguments;
     };
 
     template<typename ... arglist>
@@ -453,8 +489,8 @@ namespace fakeit {
         const Sequence &s2;
 
     protected:
-        ConcatenatedSequence(const Sequence &s1, const Sequence &s2) :
-                s1(s1), s2(s2) {
+        ConcatenatedSequence(const Sequence &seq1, const Sequence &seq2) :
+                s1(seq1), s2(seq2) {
         }
 
     public:
@@ -493,8 +529,8 @@ namespace fakeit {
         const int times;
 
     protected:
-        RepeatedSequence(const Sequence &s, const int times) :
-                _s(s), times(times) {
+        RepeatedSequence(const Sequence &s, const int t) :
+                _s(s), times(t) {
         }
 
     public:
@@ -5358,7 +5394,7 @@ namespace fakeit {
 
             void **firstMethod;
 
-            Handle(void **firstMethod) : firstMethod(firstMethod) { }
+            Handle(void **method) : firstMethod(method) { }
 
         public:
 
@@ -5531,8 +5567,8 @@ namespace fakeit {
             friend struct VirtualTable<C, baseclasses...>;
             void **firstMethod;
 
-            Handle(void **firstMethod) :
-                    firstMethod(firstMethod) {
+            Handle(void **method) :
+                    firstMethod(method) {
             }
 
         public:
@@ -5618,7 +5654,7 @@ namespace fakeit {
             auto array = new void *[size + 2 + numOfCookies]{};
             array += numOfCookies;
             array++;
-            array[0] = (void *) &typeid(C);
+            array[0] = const_cast<std::type_info *>(&typeid(C));
             array++;
             return array;
         }
@@ -5636,7 +5672,7 @@ namespace fakeit {
 
     template<typename R, typename ... arglist>
     struct MethodInvocationHandler : public Destructible {
-        virtual R handleMethodInvocation(arglist &... args) = 0;
+        virtual R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) = 0;
     };
 
 }
@@ -5738,6 +5774,9 @@ namespace fakeit {
         void *_vMethod;
     };
 }
+#include <utility>
+
+
 namespace fakeit {
 
     struct InvocationHandlerCollection {
@@ -5768,18 +5807,18 @@ namespace fakeit {
 
     protected:
 
-        R methodProxy(unsigned int id, arglist &... args) {
+        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
                     (MethodInvocationHandler<R, arglist...> *) invocationHandlerCollection->getInvocatoinHandlerPtrById(
                             id);
-            return invocationHandler->handleMethodInvocation(args...);
+            return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
         template<int id>
         R methodProxyX(arglist ... args) {
-            return methodProxy(id, args...);
+            return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
     };
 }
@@ -5820,8 +5859,8 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &instance) :
-                instance(instance),
+        DynamicProxy(C &inst) :
+                instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
@@ -5845,6 +5884,7 @@ namespace fakeit {
 
         void Reset() {
             _methodMocks = {{}};
+            _methodMocks.resize(VTUtils::getVTSize<C>());
             _members = {};
             _cloneVt.copyFrom(originalVtHandle.restore());
         }
@@ -5919,8 +5959,8 @@ namespace fakeit {
         private:
             DATA_TYPE *dataMember;
         public:
-            DataMemeberWrapper(DATA_TYPE *dataMember, const arglist &... initargs) :
-                    dataMember(dataMember) {
+            DataMemeberWrapper(DATA_TYPE *dataMem, const arglist &... initargs) :
+                    dataMember(dataMem) {
                 new(dataMember) DATA_TYPE{initargs ...};
             }
 
@@ -6059,16 +6099,6 @@ namespace fakeit {
 #include <iosfwd>
 #include <type_traits>
 #include <typeinfo>
-#include <type_traits>
-#include <typeinfo>
-
-namespace fakeit {
-
-    template<class C>
-    struct naked_type {
-        typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;
-    };
-}
 
 namespace fakeit {
 
@@ -6549,9 +6579,9 @@ namespace fakeit {
             const std::vector<Destructible *> &_matchers;
         };
 
-        virtual bool matches(const std::tuple<arglist...> &actualArgs) {
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
             MatchingLambda l(_matchers);
-            fakeit::for_each(actualArgs, l);
+            fakeit::for_each(actualArguments, l);
             return l.isMatching();
         }
 
@@ -6593,8 +6623,8 @@ namespace fakeit {
     struct UserDefinedInvocationMatcher : public ActualInvocation<arglist...>::Matcher {
         virtual ~UserDefinedInvocationMatcher() = default;
 
-        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> matcher)
-                : matcher{matcher} {
+        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> match)
+                : matcher{match} {
         }
 
         virtual bool matches(ActualInvocation<arglist...> &invocation) override {
@@ -6603,13 +6633,13 @@ namespace fakeit {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             return {"( user defined matcher )"};
         }
 
     private:
-        virtual bool matches(const std::tuple<arglist...> &actualArgs) {
-            return invoke<arglist...>(matcher, actualArgs);
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
+            return invoke<typename tuple_arg<arglist>::type...>(matcher, actualArguments);
         }
 
         const std::function<bool(arglist &...)> matcher;
@@ -6627,12 +6657,13 @@ namespace fakeit {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             return {"( Any arguments )"};
         }
 
     private:
-        virtual bool matches(const std::tuple<arglist...> &) {
+
+        virtual bool matches(const ArgumentsTuple<arglist...>&) {
             return true;
         }
     };
@@ -6654,10 +6685,10 @@ namespace fakeit {
                     _matcher{matcher}, _invocationHandler{invocationHandler} {
             }
 
-            R handleMethodInvocation(arglist &... args) override {
+            R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
                 Destructible &destructable = *_invocationHandler;
                 MethodInvocationHandler<R, arglist...> &invocationHandler = dynamic_cast<MethodInvocationHandler<R, arglist...> &>(destructable);
-                return invocationHandler.handleMethodInvocation(args...);
+                return invocationHandler.handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
             }
 
             typename ActualInvocation<arglist...>::Matcher &getMatcher() const {
@@ -6736,10 +6767,10 @@ namespace fakeit {
         }
 
 
-        R handleMethodInvocation(arglist &... args) override {
+        R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
             unsigned int ordinal = Invocation::nextInvocationOrdinal();
             MethodInfo &method = this->getMethod();
-            auto actualInvoaction = new ActualInvocation<arglist...>(ordinal, method, args...);
+            auto actualInvoaction = new ActualInvocation<arglist...>(ordinal, method, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
 
 
             std::shared_ptr<Destructible> actualInvoactionDtor{actualInvoaction};
@@ -6750,7 +6781,7 @@ namespace fakeit {
                 actualInvoaction->setActualMatcher(&matcher);
                 _actualInvocations.push_back(actualInvoactionDtor);
                 try {
-                    return invocationHandler->handleMethodInvocation(args...);
+                    return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
                 } catch (NoMoreRecordedActionException &) {
                 }
             }
@@ -6770,7 +6801,7 @@ namespace fakeit {
             }
         }
 
-        void getActualInvocations(std::unordered_set<Invocation *> &into) const {
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
             for (auto destructablePtr : _actualInvocations) {
                 Invocation &invocation = asActualInvocation(*destructablePtr);
                 into.insert(&invocation);
@@ -6795,8 +6826,8 @@ namespace fakeit {
 namespace fakeit {
 
     struct Quantity {
-        Quantity(const int quantity) :
-                quantity(quantity) {
+        Quantity(const int q) :
+                quantity(q) {
         }
 
         const int quantity;
@@ -6804,8 +6835,8 @@ namespace fakeit {
 
     template<typename R>
     struct Quantifier : public Quantity {
-        Quantifier(const int quantity, const R &value) :
-                Quantity(quantity), value(value) {
+        Quantifier(const int q, const R &val) :
+                Quantity(q), value(val) {
         }
 
         const R &value;
@@ -6813,14 +6844,14 @@ namespace fakeit {
 
     template<>
     struct Quantifier<void> : public Quantity {
-        explicit Quantifier(const int quantity) :
-                Quantity(quantity) {
+        explicit Quantifier(const int q) :
+                Quantity(q) {
         }
     };
 
     struct QuantifierFunctor : public Quantifier<void> {
-        QuantifierFunctor(const int quantity) :
-                Quantifier<void>(quantity) {
+        QuantifierFunctor(const int q) :
+                Quantifier<void>(q) {
         }
 
         template<typename R>
@@ -6868,6 +6899,7 @@ namespace fakeit {
 #include <functional>
 #include <atomic>
 #include <tuple>
+#include <type_traits>
 
 
 namespace fakeit {
@@ -6876,24 +6908,24 @@ namespace fakeit {
     struct Action : public Destructible {
         virtual ~Action() = default;
 
-        virtual R invoke(arglist &... args) = 0;
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type... args) = 0;
 
         virtual bool isDone() = 0;
     };
 
     template<typename R, typename ... arglist>
-    struct Repeat : public Action<R, arglist...> {
+    struct Repeat : Action<R, arglist...> {
         virtual ~Repeat() = default;
 
-        Repeat(std::function<R(arglist &...)> f) :
-                f(f), times(1) {
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func), times(1) {
         }
 
-        Repeat(std::function<R(arglist &...)> f, long times) :
-                f(f), times(times) {
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func, long t) :
+                f(func), times(t) {
         }
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(typename fakeit::production_arg<arglist>::type... args) override {
             times--;
             return f(args...);
         }
@@ -6903,7 +6935,7 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> f;
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
         long times;
     };
 
@@ -6912,11 +6944,11 @@ namespace fakeit {
 
         virtual ~RepeatForever() = default;
 
-        RepeatForever(std::function<R(arglist &...)> f) :
-                f(f) {
+        RepeatForever(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func) {
         }
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(typename fakeit::production_arg<arglist>::type... args) override {
             return f(args...);
         }
 
@@ -6925,14 +6957,14 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> f;
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
     };
 
     template<typename R, typename ... arglist>
     struct ReturnDefaultValue : public Action<R, arglist...> {
         virtual ~ReturnDefaultValue() = default;
 
-        virtual R invoke(arglist &...) override {
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type...) override {
             return DefaultValue<R>::value();
         }
 
@@ -6944,11 +6976,11 @@ namespace fakeit {
     template<typename R, typename ... arglist>
     struct ReturnDelegateValue : public Action<R, arglist...> {
 
-        ReturnDelegateValue(std::function<R(arglist &...)> delegate) : _delegate(delegate) { }
+        ReturnDelegateValue(std::function<R(const typename fakeit::test_arg<arglist>::type...)> delegate) : _delegate(delegate) { }
 
         virtual ~ReturnDelegateValue() = default;
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type... args) override {
             return _delegate(args...);
         }
 
@@ -6957,7 +6989,7 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> _delegate;
+        std::function<R(const typename fakeit::test_arg<arglist>::type...)> _delegate;
     };
 
 }
@@ -6973,13 +7005,13 @@ namespace fakeit {
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {
-            return Do([r](const arglist &...) -> R { return r; });
+            return Do([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {
-            return Do([&r](const arglist &...) -> R { return r; });
+            return Do([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         MethodStubbingProgress<R, arglist...> &
@@ -7000,27 +7032,27 @@ namespace fakeit {
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, void>::type
         AlwaysReturn(const R &r) {
-            return AlwaysDo([r](const arglist &...) -> R { return r; });
+            return AlwaysDo([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, void>::type
         AlwaysReturn(const R &r) {
-            return AlwaysDo([&r](const arglist &...) -> R { return r; });
+            return AlwaysDo([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         MethodStubbingProgress<R, arglist...> &
         Return() {
-            return Do([](const arglist &...) -> R { return DefaultValue<R>::value(); });
+            return Do([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
         }
 
         void AlwaysReturn() {
-            return AlwaysDo([](const arglist &...) -> R { return DefaultValue<R>::value(); });
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
         }
 
         template<typename E>
         MethodStubbingProgress<R, arglist...> &Throw(const E &e) {
-            return Do([e](const arglist &...) -> R { throw e; });
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
         }
 
         template<typename E>
@@ -7040,11 +7072,11 @@ namespace fakeit {
 
         template<typename E>
         void AlwaysThrow(const E &e) {
-            return AlwaysDo([e](const arglist &...) -> R { throw e; });
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
         }
 
         virtual MethodStubbingProgress<R, arglist...> &
-        Do(std::function<R(arglist &...)> method) {
+            Do(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             return DoImpl(new Repeat<R, arglist...>(method));
         }
 
@@ -7061,7 +7093,7 @@ namespace fakeit {
             return Do(s, t...);
         }
 
-        virtual void AlwaysDo(std::function<R(arglist &...)> method) {
+        virtual void AlwaysDo(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             DoImpl(new RepeatForever<R, arglist...>(method));
         }
 
@@ -7081,11 +7113,20 @@ namespace fakeit {
         }
 
         MethodStubbingProgress<void, arglist...> &Return() {
-            return Do([](const arglist &...) -> void { return DefaultValue<void>::value(); });
+            auto lambda = [](const typename fakeit::test_arg<arglist>::type...) -> void {
+                return DefaultValue<void>::value();
+            };
+            return Do(lambda);
         }
 
+        virtual MethodStubbingProgress<void, arglist...> &Do(
+            std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
+            return DoImpl(new Repeat<void, arglist...>(method));
+        }
+
+
         void AlwaysReturn() {
-            return AlwaysDo([](const arglist &...) -> void { return DefaultValue<void>::value(); });
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> void { return DefaultValue<void>::value(); });
         }
 
         MethodStubbingProgress<void, arglist...> &
@@ -7096,14 +7137,14 @@ namespace fakeit {
 
         template<typename E>
         MethodStubbingProgress<void, arglist...> &Throw(const E &e) {
-            return Do([e](const arglist &...) -> void { throw e; });
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
         }
 
         template<typename E>
         MethodStubbingProgress<void, arglist...> &
         Throw(const Quantifier<E> &q) {
             const E &value = q.value;
-            auto method = [value](const arglist &...) -> void { throw value; };
+            auto method = [value](const typename fakeit::test_arg<arglist>::type...) -> void { throw value; };
             return DoImpl(new Repeat<void, arglist...>(method, q.quantity));
         }
 
@@ -7116,14 +7157,10 @@ namespace fakeit {
 
         template<typename E>
         void AlwaysThrow(const E e) {
-            return AlwaysDo([e](const arglist &...) -> void { throw e; });
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
         }
 
-        virtual MethodStubbingProgress<void, arglist...> &Do(std::function<void(arglist &...)> method) {
-            return DoImpl(new Repeat<void, arglist...>(method));
-        }
-
-        template<typename F>
+           template<typename F>
         MethodStubbingProgress<void, arglist...> &
         Do(const Quantifier<F> &q) {
             return DoImpl(new Repeat<void, arglist...>(q.value, q.quantity));
@@ -7136,7 +7173,7 @@ namespace fakeit {
             return Do(s, t...);
         }
 
-        virtual void AlwaysDo(std::function<void(arglist &...)> method) {
+        virtual void AlwaysDo(std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
             DoImpl(new RepeatForever<void, arglist...>(method));
         }
 
@@ -7188,7 +7225,7 @@ namespace fakeit {
             append(action);
         }
 
-        R handleMethodInvocation(arglist &... args) override {
+        R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
             std::shared_ptr<Destructible> destructablePtr = _recordedActions.front();
             Destructible &destructable = *destructablePtr;
             Action<R, arglist...> &action = dynamic_cast<Action<R, arglist...> &>(destructable);
@@ -7197,7 +7234,7 @@ namespace fakeit {
                     _recordedActions.erase(_recordedActions.begin());
             };
             Finally onExit(finallyClause);
-            return action.invoke(args...);
+            return action.invoke(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
     private:
@@ -7206,7 +7243,7 @@ namespace fakeit {
 
             virtual ~NoMoreRecordedAction() = default;
 
-            virtual R invoke(arglist &...) override {
+            virtual R invoke(const typename fakeit::production_arg<arglist>::type...) override {
                 throw NoMoreRecordedActionException();
             }
 
@@ -7268,10 +7305,10 @@ namespace fakeit {
 
 
     template<typename R, typename ... arglist>
-    struct SpyingContext : public Xaction {
+    struct SpyingContext : Xaction {
         virtual void appendAction(Action<R, arglist...> *action) = 0;
 
-        virtual typename std::function<R(arglist &...)> getOriginalMethod() = 0;
+        virtual std::function<R(arglist&...)> getOriginalMethod() = 0;
     };
 }
 namespace fakeit {
@@ -7390,7 +7427,7 @@ namespace fakeit {
             virtual ~Context() = default;
 
 
-            virtual std::function<R(arglist &...)> getOriginalMethod() = 0;
+            virtual typename std::function<R(arglist&...)> getOriginalMethod() = 0;
 
             virtual std::string getMethodName() = 0;
 
@@ -7476,7 +7513,7 @@ namespace fakeit {
                 getRecordedActionSequence().AppendDo(action);
             }
 
-            void setMethodBodyByAssignment(std::function<R(arglist &...)> method) {
+            void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
                 appendAction(new RepeatForever<R, arglist...>(method));
                 commit();
             }
@@ -7515,7 +7552,7 @@ namespace fakeit {
 
         virtual ~MethodMockingContext() { }
 
-        std::string format() const {
+        std::string format() const override {
             return _impl->format();
         }
 
@@ -7569,7 +7606,7 @@ namespace fakeit {
             _impl->appendAction(action);
         }
 
-        void setMethodBodyByAssignment(std::function<R(arglist &...)> method) {
+        void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             _impl->setMethodBodyByAssignment(method);
         }
 
@@ -7586,7 +7623,7 @@ namespace fakeit {
 
     private:
 
-        std::function<R(arglist &...)> getOriginalMethod() override {
+        typename std::function<R(arglist&...)> getOriginalMethod() override {
             return _impl->getOriginalMethod();
         }
 
@@ -7647,13 +7684,13 @@ namespace fakeit {
 
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, void>::type operator=(const R &r) {
-            auto method = [r](arglist &...) -> R { return r; };
+            auto method = [r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
             MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, void>::type operator=(const R &r) {
-            auto method = [&r](arglist &...) -> R { return r; };
+            auto method = [&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
             MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
         }
     };
@@ -7738,6 +7775,7 @@ namespace fakeit {
 }
 
 namespace fakeit {
+
 
     template<typename C, typename ... baseclasses>
     class MockImpl : private MockObject<C>, public virtual ActualInvocationsSource {
@@ -7858,12 +7896,6 @@ namespace fakeit {
 
             R (C::*_vMethod)(arglist...);
 
-#if defined (__GNUG__)
-            typedef R(*VTableMethodType)(void *, arglist...);
-#elif defined (_MSC_VER)
-            typedef R(__thiscall *VTableMethodType)(void *, arglist...);
-#endif
-
         public:
             virtual ~MethodMockingContextImpl() = default;
 
@@ -7871,12 +7903,13 @@ namespace fakeit {
                     : MethodMockingContextBase<R, arglist...>(mock), _vMethod(vMethod) {
             }
 
-            virtual std::function<R(arglist &...)> getOriginalMethod() override {
+
+            virtual std::function<R(arglist&...)> getOriginalMethod() override {
                 void *mPtr = MethodMockingContextBase<R, arglist...>::_mock.getOriginalMethod(_vMethod);
                 C * instance = &(MethodMockingContextBase<R, arglist...>::_mock.get());
-                return [=](arglist &... args) -> R {
-                    auto m = union_cast<VTableMethodType>(mPtr);
-                    return m(instance, args...);
+                return [=](arglist&... args) -> R {
+                    auto m = union_cast<typename VTableMethodType<R,arglist...>::type>(mPtr);
+                    return m(instance, std::forward<arglist>(args)...);
                 };
             }
         };
@@ -8260,7 +8293,7 @@ namespace fakeit {
     public:
 
         template<typename R, typename ... arglist>
-        struct MethodProgress : public MethodStubbingProgress<R, arglist...> {
+        struct MethodProgress : MethodStubbingProgress<R, arglist...> {
 
             friend class WhenFunctor;
 
@@ -9110,13 +9143,13 @@ namespace fakeit {
     mock.dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    mock.stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    mock.stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    mock.stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/standalone/fakeit.hpp
+++ b/single_header/standalone/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2015-05-19 22:57:57.363000
+ *  Generated: 2015-08-14 10:23:08.133090
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -29,6 +29,40 @@
 #include <string>
 #include <iosfwd>
 #include <atomic>
+#include <tuple>
+
+
+namespace fakeit {
+
+    template<class C>
+    struct naked_type {
+        typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;
+    };
+
+    template< class T > struct tuple_arg         { typedef T  type; };
+    template< class T > struct tuple_arg < T& >  { typedef T& type; };
+    template< class T > struct tuple_arg < T&& > { typedef T&&  type; };
+
+    template<typename... arglist>
+    using ArgumentsTuple = std::tuple<typename tuple_arg<arglist>::type...>;
+
+    template< class T > struct test_arg         { typedef T& type; };
+    template< class T > struct test_arg< T& >   { typedef T& type; };
+    template< class T > struct test_arg< T&& >  { typedef T& type; };
+
+    template< class T > struct production_arg         { typedef T& type; };
+    template< class T > struct production_arg< T& >   { typedef T& type; };
+    template< class T > struct production_arg< T&& >  { typedef T&&  type; };
+
+    template<typename R, typename... arglist>
+    struct VTableMethodType {
+#if defined (__GNUG__)
+        typedef R(*type)(void *, arglist...);
+#elif defined (_MSC_VER)
+        typedef R(__thiscall *type)(void *, arglist...);
+#endif
+    };
+}
 #include <typeinfo>
 #include <tuple>
 #include <string>
@@ -305,11 +339,13 @@ namespace fakeit {
             virtual std::string format() const = 0;
         };
 
-        ActualInvocation(unsigned int ordinal, MethodInfo &method, const arglist &... args) :
-                Invocation(ordinal, method), _matcher{nullptr}, actualArguments{args...} {
+        ActualInvocation(unsigned int ordinal, MethodInfo &method, const typename fakeit::production_arg<arglist>::type... args) :
+            Invocation(ordinal, method), _matcher{ nullptr }
+            , actualArguments{ std::forward<const typename fakeit::production_arg<arglist>::type>(args)... }
+        {
         }
 
-        const std::tuple<arglist...> &getActualArguments() const {
+        ArgumentsTuple<arglist...> & getActualArguments() {
             return actualArguments;
         }
 
@@ -322,7 +358,7 @@ namespace fakeit {
             return _matcher;
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             std::ostringstream out;
             out << getMethod().name();
             print(out, actualArguments);
@@ -331,7 +367,7 @@ namespace fakeit {
 
     private:
         Matcher *_matcher;
-        std::tuple<arglist...> actualArguments;
+        ArgumentsTuple<arglist...> actualArguments;
     };
 
     template<typename ... arglist>
@@ -452,8 +488,8 @@ namespace fakeit {
         const Sequence &s2;
 
     protected:
-        ConcatenatedSequence(const Sequence &s1, const Sequence &s2) :
-                s1(s1), s2(s2) {
+        ConcatenatedSequence(const Sequence &seq1, const Sequence &seq2) :
+                s1(seq1), s2(seq2) {
         }
 
     public:
@@ -492,8 +528,8 @@ namespace fakeit {
         const int times;
 
     protected:
-        RepeatedSequence(const Sequence &s, const int times) :
-                _s(s), times(times) {
+        RepeatedSequence(const Sequence &s, const int t) :
+                _s(s), times(t) {
         }
 
     public:
@@ -5396,7 +5432,7 @@ namespace fakeit {
 
             void **firstMethod;
 
-            Handle(void **firstMethod) : firstMethod(firstMethod) { }
+            Handle(void **method) : firstMethod(method) { }
 
         public:
 
@@ -5569,8 +5605,8 @@ namespace fakeit {
             friend struct VirtualTable<C, baseclasses...>;
             void **firstMethod;
 
-            Handle(void **firstMethod) :
-                    firstMethod(firstMethod) {
+            Handle(void **method) :
+                    firstMethod(method) {
             }
 
         public:
@@ -5656,7 +5692,7 @@ namespace fakeit {
             auto array = new void *[size + 2 + numOfCookies]{};
             array += numOfCookies;
             array++;
-            array[0] = (void *) &typeid(C);
+            array[0] = const_cast<std::type_info *>(&typeid(C));
             array++;
             return array;
         }
@@ -5674,7 +5710,7 @@ namespace fakeit {
 
     template<typename R, typename ... arglist>
     struct MethodInvocationHandler : public Destructible {
-        virtual R handleMethodInvocation(arglist &... args) = 0;
+        virtual R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) = 0;
     };
 
 }
@@ -5776,6 +5812,9 @@ namespace fakeit {
         void *_vMethod;
     };
 }
+#include <utility>
+
+
 namespace fakeit {
 
     struct InvocationHandlerCollection {
@@ -5806,18 +5845,18 @@ namespace fakeit {
 
     protected:
 
-        R methodProxy(unsigned int id, arglist &... args) {
+        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
                     (MethodInvocationHandler<R, arglist...> *) invocationHandlerCollection->getInvocatoinHandlerPtrById(
                             id);
-            return invocationHandler->handleMethodInvocation(args...);
+            return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
         template<int id>
         R methodProxyX(arglist ... args) {
-            return methodProxy(id, args...);
+            return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
     };
 }
@@ -5858,8 +5897,8 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &instance) :
-                instance(instance),
+        DynamicProxy(C &inst) :
+                instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
@@ -5883,6 +5922,7 @@ namespace fakeit {
 
         void Reset() {
             _methodMocks = {{}};
+            _methodMocks.resize(VTUtils::getVTSize<C>());
             _members = {};
             _cloneVt.copyFrom(originalVtHandle.restore());
         }
@@ -5957,8 +5997,8 @@ namespace fakeit {
         private:
             DATA_TYPE *dataMember;
         public:
-            DataMemeberWrapper(DATA_TYPE *dataMember, const arglist &... initargs) :
-                    dataMember(dataMember) {
+            DataMemeberWrapper(DATA_TYPE *dataMem, const arglist &... initargs) :
+                    dataMember(dataMem) {
                 new(dataMember) DATA_TYPE{initargs ...};
             }
 
@@ -6097,16 +6137,6 @@ namespace fakeit {
 #include <iosfwd>
 #include <type_traits>
 #include <typeinfo>
-#include <type_traits>
-#include <typeinfo>
-
-namespace fakeit {
-
-    template<class C>
-    struct naked_type {
-        typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;
-    };
-}
 
 namespace fakeit {
 
@@ -6587,9 +6617,9 @@ namespace fakeit {
             const std::vector<Destructible *> &_matchers;
         };
 
-        virtual bool matches(const std::tuple<arglist...> &actualArgs) {
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
             MatchingLambda l(_matchers);
-            fakeit::for_each(actualArgs, l);
+            fakeit::for_each(actualArguments, l);
             return l.isMatching();
         }
 
@@ -6631,8 +6661,8 @@ namespace fakeit {
     struct UserDefinedInvocationMatcher : public ActualInvocation<arglist...>::Matcher {
         virtual ~UserDefinedInvocationMatcher() = default;
 
-        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> matcher)
-                : matcher{matcher} {
+        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> match)
+                : matcher{match} {
         }
 
         virtual bool matches(ActualInvocation<arglist...> &invocation) override {
@@ -6641,13 +6671,13 @@ namespace fakeit {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             return {"( user defined matcher )"};
         }
 
     private:
-        virtual bool matches(const std::tuple<arglist...> &actualArgs) {
-            return invoke<arglist...>(matcher, actualArgs);
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
+            return invoke<typename tuple_arg<arglist>::type...>(matcher, actualArguments);
         }
 
         const std::function<bool(arglist &...)> matcher;
@@ -6665,12 +6695,13 @@ namespace fakeit {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             return {"( Any arguments )"};
         }
 
     private:
-        virtual bool matches(const std::tuple<arglist...> &) {
+
+        virtual bool matches(const ArgumentsTuple<arglist...>&) {
             return true;
         }
     };
@@ -6692,10 +6723,10 @@ namespace fakeit {
                     _matcher{matcher}, _invocationHandler{invocationHandler} {
             }
 
-            R handleMethodInvocation(arglist &... args) override {
+            R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
                 Destructible &destructable = *_invocationHandler;
                 MethodInvocationHandler<R, arglist...> &invocationHandler = dynamic_cast<MethodInvocationHandler<R, arglist...> &>(destructable);
-                return invocationHandler.handleMethodInvocation(args...);
+                return invocationHandler.handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
             }
 
             typename ActualInvocation<arglist...>::Matcher &getMatcher() const {
@@ -6774,10 +6805,10 @@ namespace fakeit {
         }
 
 
-        R handleMethodInvocation(arglist &... args) override {
+        R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
             unsigned int ordinal = Invocation::nextInvocationOrdinal();
             MethodInfo &method = this->getMethod();
-            auto actualInvoaction = new ActualInvocation<arglist...>(ordinal, method, args...);
+            auto actualInvoaction = new ActualInvocation<arglist...>(ordinal, method, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
 
 
             std::shared_ptr<Destructible> actualInvoactionDtor{actualInvoaction};
@@ -6788,7 +6819,7 @@ namespace fakeit {
                 actualInvoaction->setActualMatcher(&matcher);
                 _actualInvocations.push_back(actualInvoactionDtor);
                 try {
-                    return invocationHandler->handleMethodInvocation(args...);
+                    return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
                 } catch (NoMoreRecordedActionException &) {
                 }
             }
@@ -6808,7 +6839,7 @@ namespace fakeit {
             }
         }
 
-        void getActualInvocations(std::unordered_set<Invocation *> &into) const {
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
             for (auto destructablePtr : _actualInvocations) {
                 Invocation &invocation = asActualInvocation(*destructablePtr);
                 into.insert(&invocation);
@@ -6833,8 +6864,8 @@ namespace fakeit {
 namespace fakeit {
 
     struct Quantity {
-        Quantity(const int quantity) :
-                quantity(quantity) {
+        Quantity(const int q) :
+                quantity(q) {
         }
 
         const int quantity;
@@ -6842,8 +6873,8 @@ namespace fakeit {
 
     template<typename R>
     struct Quantifier : public Quantity {
-        Quantifier(const int quantity, const R &value) :
-                Quantity(quantity), value(value) {
+        Quantifier(const int q, const R &val) :
+                Quantity(q), value(val) {
         }
 
         const R &value;
@@ -6851,14 +6882,14 @@ namespace fakeit {
 
     template<>
     struct Quantifier<void> : public Quantity {
-        explicit Quantifier(const int quantity) :
-                Quantity(quantity) {
+        explicit Quantifier(const int q) :
+                Quantity(q) {
         }
     };
 
     struct QuantifierFunctor : public Quantifier<void> {
-        QuantifierFunctor(const int quantity) :
-                Quantifier<void>(quantity) {
+        QuantifierFunctor(const int q) :
+                Quantifier<void>(q) {
         }
 
         template<typename R>
@@ -6906,6 +6937,7 @@ namespace fakeit {
 #include <functional>
 #include <atomic>
 #include <tuple>
+#include <type_traits>
 
 
 namespace fakeit {
@@ -6914,24 +6946,24 @@ namespace fakeit {
     struct Action : public Destructible {
         virtual ~Action() = default;
 
-        virtual R invoke(arglist &... args) = 0;
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type... args) = 0;
 
         virtual bool isDone() = 0;
     };
 
     template<typename R, typename ... arglist>
-    struct Repeat : public Action<R, arglist...> {
+    struct Repeat : Action<R, arglist...> {
         virtual ~Repeat() = default;
 
-        Repeat(std::function<R(arglist &...)> f) :
-                f(f), times(1) {
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func), times(1) {
         }
 
-        Repeat(std::function<R(arglist &...)> f, long times) :
-                f(f), times(times) {
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func, long t) :
+                f(func), times(t) {
         }
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(typename fakeit::production_arg<arglist>::type... args) override {
             times--;
             return f(args...);
         }
@@ -6941,7 +6973,7 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> f;
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
         long times;
     };
 
@@ -6950,11 +6982,11 @@ namespace fakeit {
 
         virtual ~RepeatForever() = default;
 
-        RepeatForever(std::function<R(arglist &...)> f) :
-                f(f) {
+        RepeatForever(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func) {
         }
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(typename fakeit::production_arg<arglist>::type... args) override {
             return f(args...);
         }
 
@@ -6963,14 +6995,14 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> f;
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
     };
 
     template<typename R, typename ... arglist>
     struct ReturnDefaultValue : public Action<R, arglist...> {
         virtual ~ReturnDefaultValue() = default;
 
-        virtual R invoke(arglist &...) override {
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type...) override {
             return DefaultValue<R>::value();
         }
 
@@ -6982,11 +7014,11 @@ namespace fakeit {
     template<typename R, typename ... arglist>
     struct ReturnDelegateValue : public Action<R, arglist...> {
 
-        ReturnDelegateValue(std::function<R(arglist &...)> delegate) : _delegate(delegate) { }
+        ReturnDelegateValue(std::function<R(const typename fakeit::test_arg<arglist>::type...)> delegate) : _delegate(delegate) { }
 
         virtual ~ReturnDelegateValue() = default;
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type... args) override {
             return _delegate(args...);
         }
 
@@ -6995,7 +7027,7 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> _delegate;
+        std::function<R(const typename fakeit::test_arg<arglist>::type...)> _delegate;
     };
 
 }
@@ -7011,13 +7043,13 @@ namespace fakeit {
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {
-            return Do([r](const arglist &...) -> R { return r; });
+            return Do([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {
-            return Do([&r](const arglist &...) -> R { return r; });
+            return Do([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         MethodStubbingProgress<R, arglist...> &
@@ -7038,27 +7070,27 @@ namespace fakeit {
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, void>::type
         AlwaysReturn(const R &r) {
-            return AlwaysDo([r](const arglist &...) -> R { return r; });
+            return AlwaysDo([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, void>::type
         AlwaysReturn(const R &r) {
-            return AlwaysDo([&r](const arglist &...) -> R { return r; });
+            return AlwaysDo([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         MethodStubbingProgress<R, arglist...> &
         Return() {
-            return Do([](const arglist &...) -> R { return DefaultValue<R>::value(); });
+            return Do([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
         }
 
         void AlwaysReturn() {
-            return AlwaysDo([](const arglist &...) -> R { return DefaultValue<R>::value(); });
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
         }
 
         template<typename E>
         MethodStubbingProgress<R, arglist...> &Throw(const E &e) {
-            return Do([e](const arglist &...) -> R { throw e; });
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
         }
 
         template<typename E>
@@ -7078,11 +7110,11 @@ namespace fakeit {
 
         template<typename E>
         void AlwaysThrow(const E &e) {
-            return AlwaysDo([e](const arglist &...) -> R { throw e; });
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
         }
 
         virtual MethodStubbingProgress<R, arglist...> &
-        Do(std::function<R(arglist &...)> method) {
+            Do(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             return DoImpl(new Repeat<R, arglist...>(method));
         }
 
@@ -7099,7 +7131,7 @@ namespace fakeit {
             return Do(s, t...);
         }
 
-        virtual void AlwaysDo(std::function<R(arglist &...)> method) {
+        virtual void AlwaysDo(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             DoImpl(new RepeatForever<R, arglist...>(method));
         }
 
@@ -7119,11 +7151,20 @@ namespace fakeit {
         }
 
         MethodStubbingProgress<void, arglist...> &Return() {
-            return Do([](const arglist &...) -> void { return DefaultValue<void>::value(); });
+            auto lambda = [](const typename fakeit::test_arg<arglist>::type...) -> void {
+                return DefaultValue<void>::value();
+            };
+            return Do(lambda);
         }
 
+        virtual MethodStubbingProgress<void, arglist...> &Do(
+            std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
+            return DoImpl(new Repeat<void, arglist...>(method));
+        }
+
+
         void AlwaysReturn() {
-            return AlwaysDo([](const arglist &...) -> void { return DefaultValue<void>::value(); });
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> void { return DefaultValue<void>::value(); });
         }
 
         MethodStubbingProgress<void, arglist...> &
@@ -7134,14 +7175,14 @@ namespace fakeit {
 
         template<typename E>
         MethodStubbingProgress<void, arglist...> &Throw(const E &e) {
-            return Do([e](const arglist &...) -> void { throw e; });
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
         }
 
         template<typename E>
         MethodStubbingProgress<void, arglist...> &
         Throw(const Quantifier<E> &q) {
             const E &value = q.value;
-            auto method = [value](const arglist &...) -> void { throw value; };
+            auto method = [value](const typename fakeit::test_arg<arglist>::type...) -> void { throw value; };
             return DoImpl(new Repeat<void, arglist...>(method, q.quantity));
         }
 
@@ -7154,14 +7195,10 @@ namespace fakeit {
 
         template<typename E>
         void AlwaysThrow(const E e) {
-            return AlwaysDo([e](const arglist &...) -> void { throw e; });
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
         }
 
-        virtual MethodStubbingProgress<void, arglist...> &Do(std::function<void(arglist &...)> method) {
-            return DoImpl(new Repeat<void, arglist...>(method));
-        }
-
-        template<typename F>
+           template<typename F>
         MethodStubbingProgress<void, arglist...> &
         Do(const Quantifier<F> &q) {
             return DoImpl(new Repeat<void, arglist...>(q.value, q.quantity));
@@ -7174,7 +7211,7 @@ namespace fakeit {
             return Do(s, t...);
         }
 
-        virtual void AlwaysDo(std::function<void(arglist &...)> method) {
+        virtual void AlwaysDo(std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
             DoImpl(new RepeatForever<void, arglist...>(method));
         }
 
@@ -7226,7 +7263,7 @@ namespace fakeit {
             append(action);
         }
 
-        R handleMethodInvocation(arglist &... args) override {
+        R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
             std::shared_ptr<Destructible> destructablePtr = _recordedActions.front();
             Destructible &destructable = *destructablePtr;
             Action<R, arglist...> &action = dynamic_cast<Action<R, arglist...> &>(destructable);
@@ -7235,7 +7272,7 @@ namespace fakeit {
                     _recordedActions.erase(_recordedActions.begin());
             };
             Finally onExit(finallyClause);
-            return action.invoke(args...);
+            return action.invoke(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
     private:
@@ -7244,7 +7281,7 @@ namespace fakeit {
 
             virtual ~NoMoreRecordedAction() = default;
 
-            virtual R invoke(arglist &...) override {
+            virtual R invoke(const typename fakeit::production_arg<arglist>::type...) override {
                 throw NoMoreRecordedActionException();
             }
 
@@ -7306,10 +7343,10 @@ namespace fakeit {
 
 
     template<typename R, typename ... arglist>
-    struct SpyingContext : public Xaction {
+    struct SpyingContext : Xaction {
         virtual void appendAction(Action<R, arglist...> *action) = 0;
 
-        virtual typename std::function<R(arglist &...)> getOriginalMethod() = 0;
+        virtual std::function<R(arglist&...)> getOriginalMethod() = 0;
     };
 }
 namespace fakeit {
@@ -7428,7 +7465,7 @@ namespace fakeit {
             virtual ~Context() = default;
 
 
-            virtual std::function<R(arglist &...)> getOriginalMethod() = 0;
+            virtual typename std::function<R(arglist&...)> getOriginalMethod() = 0;
 
             virtual std::string getMethodName() = 0;
 
@@ -7514,7 +7551,7 @@ namespace fakeit {
                 getRecordedActionSequence().AppendDo(action);
             }
 
-            void setMethodBodyByAssignment(std::function<R(arglist &...)> method) {
+            void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
                 appendAction(new RepeatForever<R, arglist...>(method));
                 commit();
             }
@@ -7553,7 +7590,7 @@ namespace fakeit {
 
         virtual ~MethodMockingContext() { }
 
-        std::string format() const {
+        std::string format() const override {
             return _impl->format();
         }
 
@@ -7607,7 +7644,7 @@ namespace fakeit {
             _impl->appendAction(action);
         }
 
-        void setMethodBodyByAssignment(std::function<R(arglist &...)> method) {
+        void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             _impl->setMethodBodyByAssignment(method);
         }
 
@@ -7624,7 +7661,7 @@ namespace fakeit {
 
     private:
 
-        std::function<R(arglist &...)> getOriginalMethod() override {
+        typename std::function<R(arglist&...)> getOriginalMethod() override {
             return _impl->getOriginalMethod();
         }
 
@@ -7685,13 +7722,13 @@ namespace fakeit {
 
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, void>::type operator=(const R &r) {
-            auto method = [r](arglist &...) -> R { return r; };
+            auto method = [r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
             MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, void>::type operator=(const R &r) {
-            auto method = [&r](arglist &...) -> R { return r; };
+            auto method = [&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
             MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
         }
     };
@@ -7776,6 +7813,7 @@ namespace fakeit {
 }
 
 namespace fakeit {
+
 
     template<typename C, typename ... baseclasses>
     class MockImpl : private MockObject<C>, public virtual ActualInvocationsSource {
@@ -7896,12 +7934,6 @@ namespace fakeit {
 
             R (C::*_vMethod)(arglist...);
 
-#if defined (__GNUG__)
-            typedef R(*VTableMethodType)(void *, arglist...);
-#elif defined (_MSC_VER)
-            typedef R(__thiscall *VTableMethodType)(void *, arglist...);
-#endif
-
         public:
             virtual ~MethodMockingContextImpl() = default;
 
@@ -7909,12 +7941,13 @@ namespace fakeit {
                     : MethodMockingContextBase<R, arglist...>(mock), _vMethod(vMethod) {
             }
 
-            virtual std::function<R(arglist &...)> getOriginalMethod() override {
+
+            virtual std::function<R(arglist&...)> getOriginalMethod() override {
                 void *mPtr = MethodMockingContextBase<R, arglist...>::_mock.getOriginalMethod(_vMethod);
                 C * instance = &(MethodMockingContextBase<R, arglist...>::_mock.get());
-                return [=](arglist &... args) -> R {
-                    auto m = union_cast<VTableMethodType>(mPtr);
-                    return m(instance, args...);
+                return [=](arglist&... args) -> R {
+                    auto m = union_cast<typename VTableMethodType<R,arglist...>::type>(mPtr);
+                    return m(instance, std::forward<arglist>(args)...);
                 };
             }
         };
@@ -8298,7 +8331,7 @@ namespace fakeit {
     public:
 
         template<typename R, typename ... arglist>
-        struct MethodProgress : public MethodStubbingProgress<R, arglist...> {
+        struct MethodProgress : MethodStubbingProgress<R, arglist...> {
 
             friend class WhenFunctor;
 
@@ -9148,13 +9181,13 @@ namespace fakeit {
     mock.dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    mock.stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    mock.stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    mock.stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2015-05-19 22:57:50.231000
+ *  Generated: 2015-08-14 10:23:20.822109
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -30,6 +30,40 @@
 #include <string>
 #include <iosfwd>
 #include <atomic>
+#include <tuple>
+
+
+namespace fakeit {
+
+    template<class C>
+    struct naked_type {
+        typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;
+    };
+
+    template< class T > struct tuple_arg         { typedef T  type; };
+    template< class T > struct tuple_arg < T& >  { typedef T& type; };
+    template< class T > struct tuple_arg < T&& > { typedef T&&  type; };
+
+    template<typename... arglist>
+    using ArgumentsTuple = std::tuple<typename tuple_arg<arglist>::type...>;
+
+    template< class T > struct test_arg         { typedef T& type; };
+    template< class T > struct test_arg< T& >   { typedef T& type; };
+    template< class T > struct test_arg< T&& >  { typedef T& type; };
+
+    template< class T > struct production_arg         { typedef T& type; };
+    template< class T > struct production_arg< T& >   { typedef T& type; };
+    template< class T > struct production_arg< T&& >  { typedef T&&  type; };
+
+    template<typename R, typename... arglist>
+    struct VTableMethodType {
+#if defined (__GNUG__)
+        typedef R(*type)(void *, arglist...);
+#elif defined (_MSC_VER)
+        typedef R(__thiscall *type)(void *, arglist...);
+#endif
+    };
+}
 #include <typeinfo>
 #include <tuple>
 #include <string>
@@ -306,11 +340,13 @@ namespace fakeit {
             virtual std::string format() const = 0;
         };
 
-        ActualInvocation(unsigned int ordinal, MethodInfo &method, const arglist &... args) :
-                Invocation(ordinal, method), _matcher{nullptr}, actualArguments{args...} {
+        ActualInvocation(unsigned int ordinal, MethodInfo &method, const typename fakeit::production_arg<arglist>::type... args) :
+            Invocation(ordinal, method), _matcher{ nullptr }
+            , actualArguments{ std::forward<const typename fakeit::production_arg<arglist>::type>(args)... }
+        {
         }
 
-        const std::tuple<arglist...> &getActualArguments() const {
+        ArgumentsTuple<arglist...> & getActualArguments() {
             return actualArguments;
         }
 
@@ -323,7 +359,7 @@ namespace fakeit {
             return _matcher;
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             std::ostringstream out;
             out << getMethod().name();
             print(out, actualArguments);
@@ -332,7 +368,7 @@ namespace fakeit {
 
     private:
         Matcher *_matcher;
-        std::tuple<arglist...> actualArguments;
+        ArgumentsTuple<arglist...> actualArguments;
     };
 
     template<typename ... arglist>
@@ -453,8 +489,8 @@ namespace fakeit {
         const Sequence &s2;
 
     protected:
-        ConcatenatedSequence(const Sequence &s1, const Sequence &s2) :
-                s1(s1), s2(s2) {
+        ConcatenatedSequence(const Sequence &seq1, const Sequence &seq2) :
+                s1(seq1), s2(seq2) {
         }
 
     public:
@@ -493,8 +529,8 @@ namespace fakeit {
         const int times;
 
     protected:
-        RepeatedSequence(const Sequence &s, const int times) :
-                _s(s), times(times) {
+        RepeatedSequence(const Sequence &s, const int t) :
+                _s(s), times(t) {
         }
 
     public:
@@ -5367,7 +5403,7 @@ namespace fakeit {
 
             void **firstMethod;
 
-            Handle(void **firstMethod) : firstMethod(firstMethod) { }
+            Handle(void **method) : firstMethod(method) { }
 
         public:
 
@@ -5540,8 +5576,8 @@ namespace fakeit {
             friend struct VirtualTable<C, baseclasses...>;
             void **firstMethod;
 
-            Handle(void **firstMethod) :
-                    firstMethod(firstMethod) {
+            Handle(void **method) :
+                    firstMethod(method) {
             }
 
         public:
@@ -5627,7 +5663,7 @@ namespace fakeit {
             auto array = new void *[size + 2 + numOfCookies]{};
             array += numOfCookies;
             array++;
-            array[0] = (void *) &typeid(C);
+            array[0] = const_cast<std::type_info *>(&typeid(C));
             array++;
             return array;
         }
@@ -5645,7 +5681,7 @@ namespace fakeit {
 
     template<typename R, typename ... arglist>
     struct MethodInvocationHandler : public Destructible {
-        virtual R handleMethodInvocation(arglist &... args) = 0;
+        virtual R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) = 0;
     };
 
 }
@@ -5747,6 +5783,9 @@ namespace fakeit {
         void *_vMethod;
     };
 }
+#include <utility>
+
+
 namespace fakeit {
 
     struct InvocationHandlerCollection {
@@ -5777,18 +5816,18 @@ namespace fakeit {
 
     protected:
 
-        R methodProxy(unsigned int id, arglist &... args) {
+        R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
             InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
                     this);
             MethodInvocationHandler<R, arglist...> *invocationHandler =
                     (MethodInvocationHandler<R, arglist...> *) invocationHandlerCollection->getInvocatoinHandlerPtrById(
                             id);
-            return invocationHandler->handleMethodInvocation(args...);
+            return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
         template<int id>
         R methodProxyX(arglist ... args) {
-            return methodProxy(id, args...);
+            return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
     };
 }
@@ -5829,8 +5868,8 @@ namespace fakeit {
 
         static_assert(std::is_polymorphic<C>::value, "DynamicProxy requires a polymorphic type");
 
-        DynamicProxy(C &instance) :
-                instance(instance),
+        DynamicProxy(C &inst) :
+                instance(inst),
                 originalVtHandle(VirtualTable<C, baseclasses...>::getVTable(instance).createHandle()),
                 _methodMocks(VTUtils::getVTSize<C>()),
                 _offsets(VTUtils::getVTSize<C>()),
@@ -5854,6 +5893,7 @@ namespace fakeit {
 
         void Reset() {
             _methodMocks = {{}};
+            _methodMocks.resize(VTUtils::getVTSize<C>());
             _members = {};
             _cloneVt.copyFrom(originalVtHandle.restore());
         }
@@ -5928,8 +5968,8 @@ namespace fakeit {
         private:
             DATA_TYPE *dataMember;
         public:
-            DataMemeberWrapper(DATA_TYPE *dataMember, const arglist &... initargs) :
-                    dataMember(dataMember) {
+            DataMemeberWrapper(DATA_TYPE *dataMem, const arglist &... initargs) :
+                    dataMember(dataMem) {
                 new(dataMember) DATA_TYPE{initargs ...};
             }
 
@@ -6068,16 +6108,6 @@ namespace fakeit {
 #include <iosfwd>
 #include <type_traits>
 #include <typeinfo>
-#include <type_traits>
-#include <typeinfo>
-
-namespace fakeit {
-
-    template<class C>
-    struct naked_type {
-        typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;
-    };
-}
 
 namespace fakeit {
 
@@ -6558,9 +6588,9 @@ namespace fakeit {
             const std::vector<Destructible *> &_matchers;
         };
 
-        virtual bool matches(const std::tuple<arglist...> &actualArgs) {
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
             MatchingLambda l(_matchers);
-            fakeit::for_each(actualArgs, l);
+            fakeit::for_each(actualArguments, l);
             return l.isMatching();
         }
 
@@ -6602,8 +6632,8 @@ namespace fakeit {
     struct UserDefinedInvocationMatcher : public ActualInvocation<arglist...>::Matcher {
         virtual ~UserDefinedInvocationMatcher() = default;
 
-        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> matcher)
-                : matcher{matcher} {
+        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> match)
+                : matcher{match} {
         }
 
         virtual bool matches(ActualInvocation<arglist...> &invocation) override {
@@ -6612,13 +6642,13 @@ namespace fakeit {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             return {"( user defined matcher )"};
         }
 
     private:
-        virtual bool matches(const std::tuple<arglist...> &actualArgs) {
-            return invoke<arglist...>(matcher, actualArgs);
+        virtual bool matches(ArgumentsTuple<arglist...>& actualArguments) {
+            return invoke<typename tuple_arg<arglist>::type...>(matcher, actualArguments);
         }
 
         const std::function<bool(arglist &...)> matcher;
@@ -6636,12 +6666,13 @@ namespace fakeit {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const {
+        virtual std::string format() const override {
             return {"( Any arguments )"};
         }
 
     private:
-        virtual bool matches(const std::tuple<arglist...> &) {
+
+        virtual bool matches(const ArgumentsTuple<arglist...>&) {
             return true;
         }
     };
@@ -6663,10 +6694,10 @@ namespace fakeit {
                     _matcher{matcher}, _invocationHandler{invocationHandler} {
             }
 
-            R handleMethodInvocation(arglist &... args) override {
+            R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
                 Destructible &destructable = *_invocationHandler;
                 MethodInvocationHandler<R, arglist...> &invocationHandler = dynamic_cast<MethodInvocationHandler<R, arglist...> &>(destructable);
-                return invocationHandler.handleMethodInvocation(args...);
+                return invocationHandler.handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
             }
 
             typename ActualInvocation<arglist...>::Matcher &getMatcher() const {
@@ -6745,10 +6776,10 @@ namespace fakeit {
         }
 
 
-        R handleMethodInvocation(arglist &... args) override {
+        R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
             unsigned int ordinal = Invocation::nextInvocationOrdinal();
             MethodInfo &method = this->getMethod();
-            auto actualInvoaction = new ActualInvocation<arglist...>(ordinal, method, args...);
+            auto actualInvoaction = new ActualInvocation<arglist...>(ordinal, method, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
 
 
             std::shared_ptr<Destructible> actualInvoactionDtor{actualInvoaction};
@@ -6759,7 +6790,7 @@ namespace fakeit {
                 actualInvoaction->setActualMatcher(&matcher);
                 _actualInvocations.push_back(actualInvoactionDtor);
                 try {
-                    return invocationHandler->handleMethodInvocation(args...);
+                    return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
                 } catch (NoMoreRecordedActionException &) {
                 }
             }
@@ -6779,7 +6810,7 @@ namespace fakeit {
             }
         }
 
-        void getActualInvocations(std::unordered_set<Invocation *> &into) const {
+        void getActualInvocations(std::unordered_set<Invocation *> &into) const override {
             for (auto destructablePtr : _actualInvocations) {
                 Invocation &invocation = asActualInvocation(*destructablePtr);
                 into.insert(&invocation);
@@ -6804,8 +6835,8 @@ namespace fakeit {
 namespace fakeit {
 
     struct Quantity {
-        Quantity(const int quantity) :
-                quantity(quantity) {
+        Quantity(const int q) :
+                quantity(q) {
         }
 
         const int quantity;
@@ -6813,8 +6844,8 @@ namespace fakeit {
 
     template<typename R>
     struct Quantifier : public Quantity {
-        Quantifier(const int quantity, const R &value) :
-                Quantity(quantity), value(value) {
+        Quantifier(const int q, const R &val) :
+                Quantity(q), value(val) {
         }
 
         const R &value;
@@ -6822,14 +6853,14 @@ namespace fakeit {
 
     template<>
     struct Quantifier<void> : public Quantity {
-        explicit Quantifier(const int quantity) :
-                Quantity(quantity) {
+        explicit Quantifier(const int q) :
+                Quantity(q) {
         }
     };
 
     struct QuantifierFunctor : public Quantifier<void> {
-        QuantifierFunctor(const int quantity) :
-                Quantifier<void>(quantity) {
+        QuantifierFunctor(const int q) :
+                Quantifier<void>(q) {
         }
 
         template<typename R>
@@ -6877,6 +6908,7 @@ namespace fakeit {
 #include <functional>
 #include <atomic>
 #include <tuple>
+#include <type_traits>
 
 
 namespace fakeit {
@@ -6885,24 +6917,24 @@ namespace fakeit {
     struct Action : public Destructible {
         virtual ~Action() = default;
 
-        virtual R invoke(arglist &... args) = 0;
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type... args) = 0;
 
         virtual bool isDone() = 0;
     };
 
     template<typename R, typename ... arglist>
-    struct Repeat : public Action<R, arglist...> {
+    struct Repeat : Action<R, arglist...> {
         virtual ~Repeat() = default;
 
-        Repeat(std::function<R(arglist &...)> f) :
-                f(f), times(1) {
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func), times(1) {
         }
 
-        Repeat(std::function<R(arglist &...)> f, long times) :
-                f(f), times(times) {
+        Repeat(std::function<R(typename fakeit::test_arg<arglist>::type...)> func, long t) :
+                f(func), times(t) {
         }
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(typename fakeit::production_arg<arglist>::type... args) override {
             times--;
             return f(args...);
         }
@@ -6912,7 +6944,7 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> f;
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
         long times;
     };
 
@@ -6921,11 +6953,11 @@ namespace fakeit {
 
         virtual ~RepeatForever() = default;
 
-        RepeatForever(std::function<R(arglist &...)> f) :
-                f(f) {
+        RepeatForever(std::function<R(typename fakeit::test_arg<arglist>::type...)> func) :
+                f(func) {
         }
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(typename fakeit::production_arg<arglist>::type... args) override {
             return f(args...);
         }
 
@@ -6934,14 +6966,14 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> f;
+        std::function<R(typename fakeit::test_arg<arglist>::type...)> f;
     };
 
     template<typename R, typename ... arglist>
     struct ReturnDefaultValue : public Action<R, arglist...> {
         virtual ~ReturnDefaultValue() = default;
 
-        virtual R invoke(arglist &...) override {
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type...) override {
             return DefaultValue<R>::value();
         }
 
@@ -6953,11 +6985,11 @@ namespace fakeit {
     template<typename R, typename ... arglist>
     struct ReturnDelegateValue : public Action<R, arglist...> {
 
-        ReturnDelegateValue(std::function<R(arglist &...)> delegate) : _delegate(delegate) { }
+        ReturnDelegateValue(std::function<R(const typename fakeit::test_arg<arglist>::type...)> delegate) : _delegate(delegate) { }
 
         virtual ~ReturnDelegateValue() = default;
 
-        virtual R invoke(arglist &... args) override {
+        virtual R invoke(const typename fakeit::production_arg<arglist>::type... args) override {
             return _delegate(args...);
         }
 
@@ -6966,7 +6998,7 @@ namespace fakeit {
         }
 
     private:
-        std::function<R(arglist &...)> _delegate;
+        std::function<R(const typename fakeit::test_arg<arglist>::type...)> _delegate;
     };
 
 }
@@ -6982,13 +7014,13 @@ namespace fakeit {
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {
-            return Do([r](const arglist &...) -> R { return r; });
+            return Do([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {
-            return Do([&r](const arglist &...) -> R { return r; });
+            return Do([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         MethodStubbingProgress<R, arglist...> &
@@ -7009,27 +7041,27 @@ namespace fakeit {
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, void>::type
         AlwaysReturn(const R &r) {
-            return AlwaysDo([r](const arglist &...) -> R { return r; });
+            return AlwaysDo([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, void>::type
         AlwaysReturn(const R &r) {
-            return AlwaysDo([&r](const arglist &...) -> R { return r; });
+            return AlwaysDo([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
         MethodStubbingProgress<R, arglist...> &
         Return() {
-            return Do([](const arglist &...) -> R { return DefaultValue<R>::value(); });
+            return Do([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
         }
 
         void AlwaysReturn() {
-            return AlwaysDo([](const arglist &...) -> R { return DefaultValue<R>::value(); });
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });
         }
 
         template<typename E>
         MethodStubbingProgress<R, arglist...> &Throw(const E &e) {
-            return Do([e](const arglist &...) -> R { throw e; });
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
         }
 
         template<typename E>
@@ -7049,11 +7081,11 @@ namespace fakeit {
 
         template<typename E>
         void AlwaysThrow(const E &e) {
-            return AlwaysDo([e](const arglist &...) -> R { throw e; });
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
         }
 
         virtual MethodStubbingProgress<R, arglist...> &
-        Do(std::function<R(arglist &...)> method) {
+            Do(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             return DoImpl(new Repeat<R, arglist...>(method));
         }
 
@@ -7070,7 +7102,7 @@ namespace fakeit {
             return Do(s, t...);
         }
 
-        virtual void AlwaysDo(std::function<R(arglist &...)> method) {
+        virtual void AlwaysDo(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             DoImpl(new RepeatForever<R, arglist...>(method));
         }
 
@@ -7090,11 +7122,20 @@ namespace fakeit {
         }
 
         MethodStubbingProgress<void, arglist...> &Return() {
-            return Do([](const arglist &...) -> void { return DefaultValue<void>::value(); });
+            auto lambda = [](const typename fakeit::test_arg<arglist>::type...) -> void {
+                return DefaultValue<void>::value();
+            };
+            return Do(lambda);
         }
 
+        virtual MethodStubbingProgress<void, arglist...> &Do(
+            std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
+            return DoImpl(new Repeat<void, arglist...>(method));
+        }
+
+
         void AlwaysReturn() {
-            return AlwaysDo([](const arglist &...) -> void { return DefaultValue<void>::value(); });
+            return AlwaysDo([](const typename fakeit::test_arg<arglist>::type...) -> void { return DefaultValue<void>::value(); });
         }
 
         MethodStubbingProgress<void, arglist...> &
@@ -7105,14 +7146,14 @@ namespace fakeit {
 
         template<typename E>
         MethodStubbingProgress<void, arglist...> &Throw(const E &e) {
-            return Do([e](const arglist &...) -> void { throw e; });
+            return Do([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
         }
 
         template<typename E>
         MethodStubbingProgress<void, arglist...> &
         Throw(const Quantifier<E> &q) {
             const E &value = q.value;
-            auto method = [value](const arglist &...) -> void { throw value; };
+            auto method = [value](const typename fakeit::test_arg<arglist>::type...) -> void { throw value; };
             return DoImpl(new Repeat<void, arglist...>(method, q.quantity));
         }
 
@@ -7125,14 +7166,10 @@ namespace fakeit {
 
         template<typename E>
         void AlwaysThrow(const E e) {
-            return AlwaysDo([e](const arglist &...) -> void { throw e; });
+            return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
         }
 
-        virtual MethodStubbingProgress<void, arglist...> &Do(std::function<void(arglist &...)> method) {
-            return DoImpl(new Repeat<void, arglist...>(method));
-        }
-
-        template<typename F>
+           template<typename F>
         MethodStubbingProgress<void, arglist...> &
         Do(const Quantifier<F> &q) {
             return DoImpl(new Repeat<void, arglist...>(q.value, q.quantity));
@@ -7145,7 +7182,7 @@ namespace fakeit {
             return Do(s, t...);
         }
 
-        virtual void AlwaysDo(std::function<void(arglist &...)> method) {
+        virtual void AlwaysDo(std::function<void(const typename fakeit::test_arg<arglist>::type...)> method) {
             DoImpl(new RepeatForever<void, arglist...>(method));
         }
 
@@ -7197,7 +7234,7 @@ namespace fakeit {
             append(action);
         }
 
-        R handleMethodInvocation(arglist &... args) override {
+        R handleMethodInvocation(const typename fakeit::production_arg<arglist>::type... args) override {
             std::shared_ptr<Destructible> destructablePtr = _recordedActions.front();
             Destructible &destructable = *destructablePtr;
             Action<R, arglist...> &action = dynamic_cast<Action<R, arglist...> &>(destructable);
@@ -7206,7 +7243,7 @@ namespace fakeit {
                     _recordedActions.erase(_recordedActions.begin());
             };
             Finally onExit(finallyClause);
-            return action.invoke(args...);
+            return action.invoke(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
 
     private:
@@ -7215,7 +7252,7 @@ namespace fakeit {
 
             virtual ~NoMoreRecordedAction() = default;
 
-            virtual R invoke(arglist &...) override {
+            virtual R invoke(const typename fakeit::production_arg<arglist>::type...) override {
                 throw NoMoreRecordedActionException();
             }
 
@@ -7277,10 +7314,10 @@ namespace fakeit {
 
 
     template<typename R, typename ... arglist>
-    struct SpyingContext : public Xaction {
+    struct SpyingContext : Xaction {
         virtual void appendAction(Action<R, arglist...> *action) = 0;
 
-        virtual typename std::function<R(arglist &...)> getOriginalMethod() = 0;
+        virtual std::function<R(arglist&...)> getOriginalMethod() = 0;
     };
 }
 namespace fakeit {
@@ -7399,7 +7436,7 @@ namespace fakeit {
             virtual ~Context() = default;
 
 
-            virtual std::function<R(arglist &...)> getOriginalMethod() = 0;
+            virtual typename std::function<R(arglist&...)> getOriginalMethod() = 0;
 
             virtual std::string getMethodName() = 0;
 
@@ -7485,7 +7522,7 @@ namespace fakeit {
                 getRecordedActionSequence().AppendDo(action);
             }
 
-            void setMethodBodyByAssignment(std::function<R(arglist &...)> method) {
+            void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
                 appendAction(new RepeatForever<R, arglist...>(method));
                 commit();
             }
@@ -7524,7 +7561,7 @@ namespace fakeit {
 
         virtual ~MethodMockingContext() { }
 
-        std::string format() const {
+        std::string format() const override {
             return _impl->format();
         }
 
@@ -7578,7 +7615,7 @@ namespace fakeit {
             _impl->appendAction(action);
         }
 
-        void setMethodBodyByAssignment(std::function<R(arglist &...)> method) {
+        void setMethodBodyByAssignment(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             _impl->setMethodBodyByAssignment(method);
         }
 
@@ -7595,7 +7632,7 @@ namespace fakeit {
 
     private:
 
-        std::function<R(arglist &...)> getOriginalMethod() override {
+        typename std::function<R(arglist&...)> getOriginalMethod() override {
             return _impl->getOriginalMethod();
         }
 
@@ -7656,13 +7693,13 @@ namespace fakeit {
 
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, void>::type operator=(const R &r) {
-            auto method = [r](arglist &...) -> R { return r; };
+            auto method = [r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
             MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
         }
 
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, void>::type operator=(const R &r) {
-            auto method = [&r](arglist &...) -> R { return r; };
+            auto method = [&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; };
             MethodMockingContext<R, arglist...>::setMethodBodyByAssignment(method);
         }
     };
@@ -7747,6 +7784,7 @@ namespace fakeit {
 }
 
 namespace fakeit {
+
 
     template<typename C, typename ... baseclasses>
     class MockImpl : private MockObject<C>, public virtual ActualInvocationsSource {
@@ -7867,12 +7905,6 @@ namespace fakeit {
 
             R (C::*_vMethod)(arglist...);
 
-#if defined (__GNUG__)
-            typedef R(*VTableMethodType)(void *, arglist...);
-#elif defined (_MSC_VER)
-            typedef R(__thiscall *VTableMethodType)(void *, arglist...);
-#endif
-
         public:
             virtual ~MethodMockingContextImpl() = default;
 
@@ -7880,12 +7912,13 @@ namespace fakeit {
                     : MethodMockingContextBase<R, arglist...>(mock), _vMethod(vMethod) {
             }
 
-            virtual std::function<R(arglist &...)> getOriginalMethod() override {
+
+            virtual std::function<R(arglist&...)> getOriginalMethod() override {
                 void *mPtr = MethodMockingContextBase<R, arglist...>::_mock.getOriginalMethod(_vMethod);
                 C * instance = &(MethodMockingContextBase<R, arglist...>::_mock.get());
-                return [=](arglist &... args) -> R {
-                    auto m = union_cast<VTableMethodType>(mPtr);
-                    return m(instance, args...);
+                return [=](arglist&... args) -> R {
+                    auto m = union_cast<typename VTableMethodType<R,arglist...>::type>(mPtr);
+                    return m(instance, std::forward<arglist>(args)...);
                 };
             }
         };
@@ -8269,7 +8302,7 @@ namespace fakeit {
     public:
 
         template<typename R, typename ... arglist>
-        struct MethodProgress : public MethodStubbingProgress<R, arglist...> {
+        struct MethodProgress : MethodStubbingProgress<R, arglist...> {
 
             friend class WhenFunctor;
 
@@ -9119,13 +9152,13 @@ namespace fakeit {
     mock.dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    mock.stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    mock.stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    mock.stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    mock.template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)


### PR DESCRIPTION
Hello,

Time to time, after a Reset, I got an assertion error generated by std::vector when  trying to generate a Stub.

Diving into the code point that error comes from DynamicProxy. 
In DynamicProxy, after a Reset, _methodMocks size is not reset to the size of the VTable of the mocked Interface.
When calling getMethodMock method, we got an assertion error while trying to access not existing index.

I'm not really aware of all the build environment.
Do I need to commit and push generated headers files ? How do you proceed to generate them ?

Sincerely

Bertrand