### PR TITLE
ADD(TEST): Reproduce error of stubbing method after Reset

### DIFF
--- a/tests/miscellaneous_tests.cpp
+++ b/tests/miscellaneous_tests.cpp
@@ -24,7 +24,8 @@ struct Miscellaneous : tpunit::TestFixture
         TEST(Miscellaneous::mock_virtual_methods_of_base_class), //
         TEST(Miscellaneous::create_and_delete_fakit_instatnce), //
         TEST(Miscellaneous::testStubFuncWithRightValueParameter),
-        TEST(Miscellaneous::testStubProcWithRightValueParameter)
+        TEST(Miscellaneous::testStubProcWithRightValueParameter),
+        TEST(Miscellaneous::can_stub_method_after_reset)
         )
     {
     }
@@ -163,6 +164,20 @@ struct Miscellaneous : tpunit::TestFixture
         ASSERT_EQUAL(4, rv4);
         foo_mock.get().bar(5);
         ASSERT_EQUAL(5, rv5);
+    }
+
+    struct foo_bar {
+      virtual ~foo_bar() {}
+      virtual int foo() = 0;
+      virtual int bar() = 0;
+    };
+
+    void can_stub_method_after_reset() {
+      Mock<foo_bar> mock;
+      mock.Reset();
+      When(Method(mock, bar)).Return(42);
+      ASSERT_EQUAL(mock.get().bar(), 42);
+      Verify(Method(mock, bar)).Once();
     }
 
 


### PR DESCRIPTION
Created a test that reproduce the fact that when stubbing a method of a mock that has been Reseted, then got error because size of std::vector used to store stubs was not defined correctly.