### PR TITLE
Fix vs2013 compilation

### DIFF
--- a/include/mockutils/type_utils.hpp
+++ b/include/mockutils/type_utils.hpp
@@ -36,16 +36,44 @@ namespace fakeit {
     template< class T > struct production_arg< T& >   { typedef T& type; };
     template< class T > struct production_arg< T&& >  { typedef T&&  type; };
 
-	template <typename T>
-	class is_ostreamable {
-		struct no {};
-		template <typename T1>
-		static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
-		static no test(...);
-	public:
-		static const bool value = std::is_same<decltype(test(*(std::ostream *)nullptr,
-			std::declval<T>())), std::ostream &>::value;
-	};
+    template <typename T>
+    class is_ostreamable {
+        struct no {};
+#if defined(_MSC_VER) && _MSC_VER < 1900
+        template <typename T1>
+        static decltype(operator<<(std::declval<std::ostream&>(), std::declval<const T1>())) test(std::ostream &s, const T1 &t);
+#else
+        template <typename T1>
+        static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
+#endif
+        static no test(...);
+    public:
+        // capture std::ostream operator<< members for the benefit of MSVC
+        static const bool value =
+            std::is_arithmetic<T>::value ||
+            std::is_pointer<T>::value ||
+            std::is_same<decltype(test(*(std::ostream *)nullptr,
+                std::declval<T>())), std::ostream &>::value;
+    };
+
+    // capture std::ostream operator<< members for the benefit of MSVC
+    template <>
+    class is_ostreamable<std::ios_base& (*)(std::ios_base&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ios<CharT,Traits>& (*)(std::basic_ios<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ostream<CharT,Traits>& (*)(std::basic_ostream<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
 
     template<typename R, typename... arglist>
     struct VTableMethodType {

--- a/single_header/boost/fakeit.hpp
+++ b/single_header/boost/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2015-10-29 23:45:30.560000
+ *  Generated: 2016-05-12 09:58:05.070214
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -58,16 +58,44 @@ namespace fakeit {
     template< class T > struct production_arg< T& >   { typedef T& type; };
     template< class T > struct production_arg< T&& >  { typedef T&&  type; };
 
-	template <typename T>
-	class is_ostreamable {
-		struct no {};
-		template <typename T1>
-		static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
-		static no test(...);
-	public:
-		static const bool value = std::is_same<decltype(test(*(std::ostream *)nullptr,
-			std::declval<T>())), std::ostream &>::value;
-	};
+    template <typename T>
+    class is_ostreamable {
+        struct no {};
+#if defined(_MSC_VER) && _MSC_VER < 1900
+        template <typename T1>
+        static decltype(operator<<(std::declval<std::ostream&>(), std::declval<const T1>())) test(std::ostream &s, const T1 &t);
+#else
+        template <typename T1>
+        static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
+#endif
+        static no test(...);
+    public:
+
+        static const bool value =
+            std::is_arithmetic<T>::value ||
+            std::is_pointer<T>::value ||
+            std::is_same<decltype(test(*(std::ostream *)nullptr,
+                std::declval<T>())), std::ostream &>::value;
+    };
+
+
+    template <>
+    class is_ostreamable<std::ios_base& (*)(std::ios_base&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ios<CharT,Traits>& (*)(std::basic_ios<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ostream<CharT,Traits>& (*)(std::basic_ostream<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
 
     template<typename R, typename... arglist>
     struct VTableMethodType {

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2016-02-18 21:08:35.221189
+ *  Generated: 2016-05-12 09:58:05.161876
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -58,16 +58,44 @@ namespace fakeit {
     template< class T > struct production_arg< T& >   { typedef T& type; };
     template< class T > struct production_arg< T&& >  { typedef T&&  type; };
 
-	template <typename T>
-	class is_ostreamable {
-		struct no {};
-		template <typename T1>
-		static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
-		static no test(...);
-	public:
-		static const bool value = std::is_same<decltype(test(*(std::ostream *)nullptr,
-			std::declval<T>())), std::ostream &>::value;
-	};
+    template <typename T>
+    class is_ostreamable {
+        struct no {};
+#if defined(_MSC_VER) && _MSC_VER < 1900
+        template <typename T1>
+        static decltype(operator<<(std::declval<std::ostream&>(), std::declval<const T1>())) test(std::ostream &s, const T1 &t);
+#else
+        template <typename T1>
+        static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
+#endif
+        static no test(...);
+    public:
+
+        static const bool value =
+            std::is_arithmetic<T>::value ||
+            std::is_pointer<T>::value ||
+            std::is_same<decltype(test(*(std::ostream *)nullptr,
+                std::declval<T>())), std::ostream &>::value;
+    };
+
+
+    template <>
+    class is_ostreamable<std::ios_base& (*)(std::ios_base&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ios<CharT,Traits>& (*)(std::basic_ios<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ostream<CharT,Traits>& (*)(std::basic_ostream<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
 
     template<typename R, typename... arglist>
     struct VTableMethodType {

--- a/single_header/gtest/fakeit.hpp
+++ b/single_header/gtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2015-10-29 23:45:09.475000
+ *  Generated: 2016-05-12 09:58:05.214705
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -58,16 +58,44 @@ namespace fakeit {
     template< class T > struct production_arg< T& >   { typedef T& type; };
     template< class T > struct production_arg< T&& >  { typedef T&&  type; };
 
-	template <typename T>
-	class is_ostreamable {
-		struct no {};
-		template <typename T1>
-		static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
-		static no test(...);
-	public:
-		static const bool value = std::is_same<decltype(test(*(std::ostream *)nullptr,
-			std::declval<T>())), std::ostream &>::value;
-	};
+    template <typename T>
+    class is_ostreamable {
+        struct no {};
+#if defined(_MSC_VER) && _MSC_VER < 1900
+        template <typename T1>
+        static decltype(operator<<(std::declval<std::ostream&>(), std::declval<const T1>())) test(std::ostream &s, const T1 &t);
+#else
+        template <typename T1>
+        static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
+#endif
+        static no test(...);
+    public:
+
+        static const bool value =
+            std::is_arithmetic<T>::value ||
+            std::is_pointer<T>::value ||
+            std::is_same<decltype(test(*(std::ostream *)nullptr,
+                std::declval<T>())), std::ostream &>::value;
+    };
+
+
+    template <>
+    class is_ostreamable<std::ios_base& (*)(std::ios_base&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ios<CharT,Traits>& (*)(std::basic_ios<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ostream<CharT,Traits>& (*)(std::basic_ostream<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
 
     template<typename R, typename... arglist>
     struct VTableMethodType {

--- a/single_header/mstest/fakeit.hpp
+++ b/single_header/mstest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2015-10-29 23:45:13.863000
+ *  Generated: 2016-05-12 09:58:05.269556
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -58,16 +58,44 @@ namespace fakeit {
     template< class T > struct production_arg< T& >   { typedef T& type; };
     template< class T > struct production_arg< T&& >  { typedef T&&  type; };
 
-	template <typename T>
-	class is_ostreamable {
-		struct no {};
-		template <typename T1>
-		static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
-		static no test(...);
-	public:
-		static const bool value = std::is_same<decltype(test(*(std::ostream *)nullptr,
-			std::declval<T>())), std::ostream &>::value;
-	};
+    template <typename T>
+    class is_ostreamable {
+        struct no {};
+#if defined(_MSC_VER) && _MSC_VER < 1900
+        template <typename T1>
+        static decltype(operator<<(std::declval<std::ostream&>(), std::declval<const T1>())) test(std::ostream &s, const T1 &t);
+#else
+        template <typename T1>
+        static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
+#endif
+        static no test(...);
+    public:
+
+        static const bool value =
+            std::is_arithmetic<T>::value ||
+            std::is_pointer<T>::value ||
+            std::is_same<decltype(test(*(std::ostream *)nullptr,
+                std::declval<T>())), std::ostream &>::value;
+    };
+
+
+    template <>
+    class is_ostreamable<std::ios_base& (*)(std::ios_base&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ios<CharT,Traits>& (*)(std::basic_ios<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ostream<CharT,Traits>& (*)(std::basic_ostream<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
 
     template<typename R, typename... arglist>
     struct VTableMethodType {

--- a/single_header/qtest/fakeit.hpp
+++ b/single_header/qtest/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2016-04-28 20:59:42.208756
+ *  Generated: 2016-05-12 09:58:05.323377
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -58,16 +58,44 @@ namespace fakeit {
     template< class T > struct production_arg< T& >   { typedef T& type; };
     template< class T > struct production_arg< T&& >  { typedef T&&  type; };
 
-	template <typename T>
-	class is_ostreamable {
-		struct no {};
-		template <typename T1>
-		static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
-		static no test(...);
-	public:
-		static const bool value = std::is_same<decltype(test(*(std::ostream *)nullptr,
-			std::declval<T>())), std::ostream &>::value;
-	};
+    template <typename T>
+    class is_ostreamable {
+        struct no {};
+#if defined(_MSC_VER) && _MSC_VER < 1900
+        template <typename T1>
+        static decltype(operator<<(std::declval<std::ostream&>(), std::declval<const T1>())) test(std::ostream &s, const T1 &t);
+#else
+        template <typename T1>
+        static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
+#endif
+        static no test(...);
+    public:
+
+        static const bool value =
+            std::is_arithmetic<T>::value ||
+            std::is_pointer<T>::value ||
+            std::is_same<decltype(test(*(std::ostream *)nullptr,
+                std::declval<T>())), std::ostream &>::value;
+    };
+
+
+    template <>
+    class is_ostreamable<std::ios_base& (*)(std::ios_base&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ios<CharT,Traits>& (*)(std::basic_ios<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ostream<CharT,Traits>& (*)(std::basic_ostream<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
 
     template<typename R, typename... arglist>
     struct VTableMethodType {

--- a/single_header/standalone/fakeit.hpp
+++ b/single_header/standalone/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2015-10-29 23:44:56.817000
+ *  Generated: 2016-05-12 09:58:05.378151
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -57,16 +57,44 @@ namespace fakeit {
     template< class T > struct production_arg< T& >   { typedef T& type; };
     template< class T > struct production_arg< T&& >  { typedef T&&  type; };
 
-	template <typename T>
-	class is_ostreamable {
-		struct no {};
-		template <typename T1>
-		static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
-		static no test(...);
-	public:
-		static const bool value = std::is_same<decltype(test(*(std::ostream *)nullptr,
-			std::declval<T>())), std::ostream &>::value;
-	};
+    template <typename T>
+    class is_ostreamable {
+        struct no {};
+#if defined(_MSC_VER) && _MSC_VER < 1900
+        template <typename T1>
+        static decltype(operator<<(std::declval<std::ostream&>(), std::declval<const T1>())) test(std::ostream &s, const T1 &t);
+#else
+        template <typename T1>
+        static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
+#endif
+        static no test(...);
+    public:
+
+        static const bool value =
+            std::is_arithmetic<T>::value ||
+            std::is_pointer<T>::value ||
+            std::is_same<decltype(test(*(std::ostream *)nullptr,
+                std::declval<T>())), std::ostream &>::value;
+    };
+
+
+    template <>
+    class is_ostreamable<std::ios_base& (*)(std::ios_base&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ios<CharT,Traits>& (*)(std::basic_ios<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ostream<CharT,Traits>& (*)(std::basic_ostream<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
 
     template<typename R, typename... arglist>
     struct VTableMethodType {

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2015-10-29 23:45:19.948000
+ *  Generated: 2016-05-12 09:58:05.432525
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -58,16 +58,44 @@ namespace fakeit {
     template< class T > struct production_arg< T& >   { typedef T& type; };
     template< class T > struct production_arg< T&& >  { typedef T&&  type; };
 
-	template <typename T>
-	class is_ostreamable {
-		struct no {};
-		template <typename T1>
-		static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
-		static no test(...);
-	public:
-		static const bool value = std::is_same<decltype(test(*(std::ostream *)nullptr,
-			std::declval<T>())), std::ostream &>::value;
-	};
+    template <typename T>
+    class is_ostreamable {
+        struct no {};
+#if defined(_MSC_VER) && _MSC_VER < 1900
+        template <typename T1>
+        static decltype(operator<<(std::declval<std::ostream&>(), std::declval<const T1>())) test(std::ostream &s, const T1 &t);
+#else
+        template <typename T1>
+        static auto test(std::ostream &s, const T1 &t) -> decltype(s << t);
+#endif
+        static no test(...);
+    public:
+
+        static const bool value =
+            std::is_arithmetic<T>::value ||
+            std::is_pointer<T>::value ||
+            std::is_same<decltype(test(*(std::ostream *)nullptr,
+                std::declval<T>())), std::ostream &>::value;
+    };
+
+
+    template <>
+    class is_ostreamable<std::ios_base& (*)(std::ios_base&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ios<CharT,Traits>& (*)(std::basic_ios<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
+
+    template <typename CharT, typename Traits>
+    class is_ostreamable<std::basic_ostream<CharT,Traits>& (*)(std::basic_ostream<CharT,Traits>&)> {
+    public:
+        static const bool value = true;
+    };
 
     template<typename R, typename... arglist>
     struct VTableMethodType {

--- a/tests/all_tests.vcxproj
+++ b/tests/all_tests.vcxproj
@@ -140,6 +140,7 @@
     <ClCompile Include="sequence_verification_tests.cpp" />
     <ClCompile Include="spying_tests.cpp" />
     <ClCompile Include="functional.cpp" />
+    <ClCompile Include="streaming_tests.cpp" />
     <ClCompile Include="stubbing_tests.cpp" />
     <ClCompile Include="tpunit++main.cpp" />
     <ClCompile Include="type_info_tests.cpp" />

--- a/tests/streaming_tests.cpp
+++ b/tests/streaming_tests.cpp
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016 Oxford Nanopore Technologies
+ *
+ * This program is made available under the terms of the MIT License.
+ *
+ * Created on May 11, 2016
+ */
+
+#include <string>
+
+#include "tpunit++.hpp"
+#include "fakeit.hpp"
+
+using namespace fakeit;
+
+struct StreamingTests : tpunit::TestFixture {
+
+	StreamingTests() :
+	tpunit::TestFixture(
+	TEST(StreamingTests::enum_class_arg)
+	)
+	{
+	}
+    
+    enum class SomeEnum
+    {
+        Item1,
+        Item2
+    };
+
+	struct SomeInterface {
+		virtual void func(SomeEnum) = 0;
+	};
+    
+    void enum_class_arg() {
+        Mock<SomeInterface> mock;
+        When(Method(mock, func)).AlwaysReturn();
+        mock.get().func(SomeEnum::Item1);
+        Verify(Method(mock, func)).Exactly(1);
+    }
+
+} __TypeInfoTests;


### PR DESCRIPTION
This works around a compiler bug / lack of compiler support in Visual Studio 2013.

All tests pass on Visual Studio 2013, Visual Studio 2015, gcc 4.8.4 (Ubuntu 14.04) and AppleClang 7.3.0/703.0.31 (Mac OS X El Capitan).

Fixes #65.