### PR TITLE
Reset don't reinit offset vector

### DIFF
--- a/include/mockutils/DynamicProxy.hpp
+++ b/include/mockutils/DynamicProxy.hpp
@@ -84,6 +84,8 @@ namespace fakeit {
             _methodMocks = {{}};
             _methodMocks.resize(VTUtils::getVTSize<C>());
             _members = {};
+            _offsets = {};
+            _offsets.resize(VTUtils::getVTSize<C>());
             _cloneVt.copyFrom(originalVtHandle.restore());
         }
 


### PR DESCRIPTION
I wonder why we don't reinit the offset vector here ?

I got a segmentation fault today, in my test, I have a big struct contains a lot of the virtual method, called mock_a 
I have two different test class, one setting up some functions of mock_a, the other one firstly reset the mock_a, and setting up some more functions, then I ran into a segmentation fault.

I trace back, it turns out the offset vector contains the old offset which are added in the previous test class.
I think this happened because the two offset have same id.
 
however with _methodMocks have been reset, the old offset will provide a NULL pointer.
Then I have a segmentation fault.

BTW, why we need to keep track all the offsets ?
Why we don't make the whole _methodMocks as a map (id as the key)?