### PR TITLE
add integration with the Mettle unit test framework

### DIFF
--- a/config/mettle/MettleFakeit.hpp
+++ b/config/mettle/MettleFakeit.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include "fakeit/DefaultFakeit.hpp"
+
+namespace fakeit {
+
+    struct MettleAdapter : public EventHandler {
+
+        std::string formatLineNumner(std::string file, int num){
+#ifndef __GNUG__
+            return file + std::string("(") + std::to_string(num) + std::string(")");
+#else
+            return file + std::string(":") + std::to_string(num);
+#endif
+        }
+
+        virtual ~MettleAdapter() = default;
+
+        MettleAdapter(EventFormatter &formatter)
+            : _formatter(formatter) {
+        }
+
+        virtual void handle(const UnexpectedMethodCallEvent &evt) override {
+            throw mettle::expectation_error(_formatter.format(evt));
+        }
+
+        virtual void handle(const SequenceVerificationEvent &evt) override {
+            throw mettle::expectation_error(
+                    formatLineNumner(evt.file(), evt.line()) + ": " + 
+                    _formatter.format(evt));
+        }
+
+        virtual void handle(const NoMoreInvocationsVerificationEvent &evt) override {
+            throw mettle::expectation_error(
+                    formatLineNumner(evt.file(), evt.line()) + ": " + 
+                    _formatter.format(evt));
+        }
+
+    private:
+        EventFormatter &_formatter;
+    };
+
+    class MettleFakeit : public DefaultFakeit {
+
+    public:
+        virtual ~MettleFakeit() = default;
+
+        MettleFakeit() : _mettleAdapter(*this) {
+        }
+
+        static MettleFakeit &getInstance() {
+            static MettleFakeit instance;
+            return instance;
+        }
+
+    protected:
+
+        fakeit::EventHandler &accessTestingFrameworkAdapter() override {
+            return _mettleAdapter;
+        }
+
+    private:
+
+        MettleAdapter _mettleAdapter;
+    };
+}

--- a/config/mettle/fakeit.hpp
+++ b/config/mettle/fakeit.hpp
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "fakeit_instance.hpp"
+#include "fakeit/fakeit_root.hpp"

--- a/config/mettle/fakeit_instance.hpp
+++ b/config/mettle/fakeit_instance.hpp
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "MettleFakeit.hpp"
+
+static fakeit::DefaultFakeit& Fakeit = fakeit::MettleFakeit::getInstance();


### PR DESCRIPTION
[Mettle](https://jimporter.github.io/mettle/) is another nice unit test framework written by @jimporter.  This commit adds a FakeIt configuration for Mettle alongside all the other supported unit test frameworks.  The commit is basically just a copy of the standalone configuration for FakeIt, with the standalone exception types replaced with `mettle::expectation_error.`