### PR TITLE
Add missing override modifier on Matcher::matches

### DIFF
--- a/include/fakeit/argument_matchers.hpp
+++ b/include/fakeit/argument_matchers.hpp
@@ -58,7 +58,7 @@ namespace fakeit {
             }
 
             struct Matcher : public TypedMatcher<T> {
-                virtual bool matches(const T &) const {
+                virtual bool matches(const T &) const override {
                     return true;
                 }
 

--- a/single_header/boost/fakeit.hpp
+++ b/single_header/boost/fakeit.hpp
@@ -6316,7 +6316,7 @@ namespace fakeit {
             }
 
             struct Matcher : public TypedMatcher<T> {
-                virtual bool matches(const T &) const {
+                virtual bool matches(const T &) const override {
                     return true;
                 }
 

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -6369,7 +6369,7 @@ namespace fakeit {
             }
 
             struct Matcher : public TypedMatcher<T> {
-                virtual bool matches(const T &) const {
+                virtual bool matches(const T &) const override {
                     return true;
                 }
 

--- a/single_header/gtest/fakeit.hpp
+++ b/single_header/gtest/fakeit.hpp
@@ -6280,7 +6280,7 @@ namespace fakeit {
             }
 
             struct Matcher : public TypedMatcher<T> {
-                virtual bool matches(const T &) const {
+                virtual bool matches(const T &) const override {
                     return true;
                 }
 

--- a/single_header/mettle/fakeit.hpp
+++ b/single_header/mettle/fakeit.hpp
@@ -6289,7 +6289,7 @@ namespace fakeit {
             }
 
             struct Matcher : public TypedMatcher<T> {
-                virtual bool matches(const T &) const {
+                virtual bool matches(const T &) const override {
                     return true;
                 }
 

--- a/single_header/mstest/fakeit.hpp
+++ b/single_header/mstest/fakeit.hpp
@@ -6305,7 +6305,7 @@ namespace fakeit {
             }
 
             struct Matcher : public TypedMatcher<T> {
-                virtual bool matches(const T &) const {
+                virtual bool matches(const T &) const override {
                     return true;
                 }
 

--- a/single_header/qtest/fakeit.hpp
+++ b/single_header/qtest/fakeit.hpp
@@ -6289,7 +6289,7 @@ namespace fakeit {
             }
 
             struct Matcher : public TypedMatcher<T> {
-                virtual bool matches(const T &) const {
+                virtual bool matches(const T &) const override {
                     return true;
                 }
 

--- a/single_header/standalone/fakeit.hpp
+++ b/single_header/standalone/fakeit.hpp
@@ -6343,7 +6343,7 @@ namespace fakeit {
             }
 
             struct Matcher : public TypedMatcher<T> {
-                virtual bool matches(const T &) const {
+                virtual bool matches(const T &) const override {
                     return true;
                 }
 

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -6314,7 +6314,7 @@ namespace fakeit {
             }
 
             struct Matcher : public TypedMatcher<T> {
-                virtual bool matches(const T &) const {
+                virtual bool matches(const T &) const override {
                     return true;
                 }
 


### PR DESCRIPTION
Without this change, I get multiple errors of the form:

> `warning: 'matches' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]`