### PR TITLE
removing redundant "using namespace fakeit" within fakeit namespace

### DIFF
--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -15,7 +15,6 @@
 namespace fakeit {
     namespace internal {
     }
-    using namespace fakeit;
     using namespace fakeit::internal;
 
     template<typename C, typename ... baseclasses>

--- a/single_header/boost/fakeit.hpp
+++ b/single_header/boost/fakeit.hpp
@@ -8142,7 +8142,6 @@ namespace fakeit {
 namespace fakeit {
     namespace internal {
     }
-    using namespace fakeit;
     using namespace fakeit::internal;
 
     template<typename C, typename ... baseclasses>

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -8195,7 +8195,6 @@ namespace fakeit {
 namespace fakeit {
     namespace internal {
     }
-    using namespace fakeit;
     using namespace fakeit::internal;
 
     template<typename C, typename ... baseclasses>

--- a/single_header/gtest/fakeit.hpp
+++ b/single_header/gtest/fakeit.hpp
@@ -8106,7 +8106,6 @@ namespace fakeit {
 namespace fakeit {
     namespace internal {
     }
-    using namespace fakeit;
     using namespace fakeit::internal;
 
     template<typename C, typename ... baseclasses>

--- a/single_header/mettle/fakeit.hpp
+++ b/single_header/mettle/fakeit.hpp
@@ -8115,7 +8115,6 @@ namespace fakeit {
 namespace fakeit {
     namespace internal {
     }
-    using namespace fakeit;
     using namespace fakeit::internal;
 
     template<typename C, typename ... baseclasses>

--- a/single_header/mstest/fakeit.hpp
+++ b/single_header/mstest/fakeit.hpp
@@ -8131,7 +8131,6 @@ namespace fakeit {
 namespace fakeit {
     namespace internal {
     }
-    using namespace fakeit;
     using namespace fakeit::internal;
 
     template<typename C, typename ... baseclasses>

--- a/single_header/qtest/fakeit.hpp
+++ b/single_header/qtest/fakeit.hpp
@@ -8115,7 +8115,6 @@ namespace fakeit {
 namespace fakeit {
     namespace internal {
     }
-    using namespace fakeit;
     using namespace fakeit::internal;
 
     template<typename C, typename ... baseclasses>

--- a/single_header/standalone/fakeit.hpp
+++ b/single_header/standalone/fakeit.hpp
@@ -8169,7 +8169,6 @@ namespace fakeit {
 namespace fakeit {
     namespace internal {
     }
-    using namespace fakeit;
     using namespace fakeit::internal;
 
     template<typename C, typename ... baseclasses>

--- a/single_header/tpunit/fakeit.hpp
+++ b/single_header/tpunit/fakeit.hpp
@@ -8140,7 +8140,6 @@ namespace fakeit {
 namespace fakeit {
     namespace internal {
     }
-    using namespace fakeit;
     using namespace fakeit::internal;
 
     template<typename C, typename ... baseclasses>


### PR DESCRIPTION
This resolves C4515 warning (warning C4515: 'fakeit': namespace uses itself) on Visual Studio
https://msdn.microsoft.com/en-us/library/aah71ce4.aspx
