### PR TITLE
Added a macro to enable assert on unexpected method invocation

### DIFF
--- a/include/fakeit/FakeitContext.hpp
+++ b/include/fakeit/FakeitContext.hpp
@@ -21,6 +21,9 @@ namespace fakeit {
         void handle(const UnexpectedMethodCallEvent &e) override {
             fireEvent(e);
             auto &eh = getTestingFrameworkAdapter();
+            #ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+            assert(!"Unexpected method invocation");
+            #endif
             eh.handle(e);
         }
 


### PR DESCRIPTION
If FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION macros is defined before including fakeit, an assertion is fired when unmocked method is called.
This simplifies detection of unmocked method using call stack tracking in debug mode.