### PR TITLE
Allow building on Mac or with specific GCC toolchains

### DIFF
--- a/build/makefile
+++ b/build/makefile
@@ -1,3 +1,5 @@
+LD := g++
+CXX := g++
 
 RM := rm -rf
 
@@ -7,38 +9,40 @@ OBJS += $(subst .cpp,.o,$(CPP_SRCS))
 
 CPP_DEPS += $(subst .cpp,.d,$(CPP_SRCS))
 
+EXE := .exe
+
 all: fakeit_test_application
 
 coverage: fakeit_test_application_with_coverage
 
 check: fakeit_test_application
-	./fakeit_tests.exe
+	./fakeit_tests$(EXE)
 
-fakeit_test_application: $(OBJS) 
-	@echo 'Building test application: fakeit_tests.exe'
+fakeit_test_application: $(OBJS)
+	@echo 'Building test application: fakeit_tests$(EXE)'
 	@echo 'Invoking: GCC C++ Linker'
-	g++ -flto -Wl,-allow-multiple-definition -o "fakeit_tests.exe" $(OBJS) 
-	@echo 'Finished building test application: fakeit_tests.exe'
+	$(LD) -flto -o "fakeit_tests$(EXE)" $(OBJS)
+	@echo 'Finished building test application: fakeit_tests$(EXE)'
 	@echo ' '
 
-fakeit_test_application_with_coverage: $(subst .cpp,_with_coverage,$(CPP_SRCS)) 
-	@echo 'Building test application: fakeit_tests.exe'
+fakeit_test_application_with_coverage: $(subst .cpp,_with_coverage,$(CPP_SRCS))
+	@echo 'Building test application: fakeit_tests$(EXE)'
 	@echo 'Invoking: GCC C++ Linker'
-	g++ --coverage -o "fakeit_tests.exe" $(OBJS) 
-	@echo 'Finished building test application: fakeit_tests.exe'
+	$(LD) --coverage -o "fakeit_tests$(EXE)" $(OBJS)
+	@echo 'Finished building test application: fakeit_tests$(EXE)'
 	@echo ' '
 
 %.o: ../tests/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C++ Compiler'
-	g++ -flto -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -Wextra -Wno-ignored-qualifiers -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
+	$(CXX) -flto -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -Wextra -Wno-ignored-qualifiers -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o "$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 
 %_with_coverage: ../tests/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking: GCC C++ Compiler'
-	g++ --coverage -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -Wextra -Wno-ignored-qualifiers -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"$(@:%_with_coverage=%.d)" -MT"$(@:%_with_coverage=%.d)" -o $(subst _with_coverage,.o,"$@") "$<"
+	$(CXX) --coverage -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -Wextra -Wno-ignored-qualifiers -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"$(@:%_with_coverage=%.d)" -MT"$(@:%_with_coverage=%.d)" -o $(subst _with_coverage,.o,"$@") "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 
@@ -48,5 +52,5 @@ endif
 
 # Other Targets
 clean:
-	-$(RM) $(OBJS)$(CPP_DEPS) fakeit_tests.exe *.gc*
+	-$(RM) $(OBJS)$(CPP_DEPS) fakeit_tests$(EXE) *.gc*
 	-@echo ' '

--- a/makefile
+++ b/makefile
@@ -1,5 +1,8 @@
 all:
-	@make -C build
+	@$(MAKE) -C build
 
 check:
-	@make -C build check
+	@$(MAKE) -C build check
+
+clean:
+	@$(MAKE) -C build clean


### PR DESCRIPTION
The existing makefiles assume a compiler and linker named `g++` and an executable extension of ".exe". To allow testing on Mac or with toolchains named differently (like `g++-7` for instance), this PR allows overloading of the `$(LD)`, `$(CXX)`, and `$(EXE)` make variables from the command line but otherwise defaults to the same `g++`/Windows build.

It also adds a  `clean` target to the top-level `makefile`.

I did have to remove the linker flag `-allow-multiple-definition`, which isn't understood by either gcc 7 or clang.