### PR TITLE
Tolerate invocations with nullptr char*

### DIFF
--- a/include/mockutils/Formatter.hpp
+++ b/include/mockutils/Formatter.hpp
@@ -37,6 +37,35 @@ namespace fakeit {
 		}
 	};
 
+	template <>
+	struct Formatter<char const*>
+	{
+		static std::string format(char const* const &val)
+		{
+			std::string s;
+			if(val != nullptr)
+			{
+				s += '"';
+				s += val;
+				s += '"';
+			}
+			else
+			{
+				s = "[nullptr]";
+			}
+			return s;
+		}
+	};
+
+	template <>
+	struct Formatter<char*>
+	{
+		static std::string format(char* const &val)
+		{
+			return Formatter<char const*>::format( val );
+		}
+	};
+
 	template<class C>
 	struct Formatter<C, typename std::enable_if<!is_ostreamable<C>::value>::type> {
 		static std::string format(C const &)

--- a/tests/verification_tests.cpp
+++ b/tests/verification_tests.cpp
@@ -63,7 +63,8 @@ struct BasicVerification: tpunit::TestFixture {
 					TEST(BasicVerification::verify_after_paramter_was_changed__with_Matching), //
 					TEST(BasicVerification::verify_after_paramter_was_changed_with_argument_matcher), //
 					TEST(BasicVerification::verify_no_invocations),
-					TEST(BasicVerification::verify_after_paramter_was_changed_with_Using)) //
+					TEST(BasicVerification::verify_after_paramter_was_changed_with_Using), //
+					TEST(BasicVerification::verificationShouldTolerateNullString))
 	{
 	}
 
@@ -569,5 +570,25 @@ struct BasicVerification: tpunit::TestFixture {
 		ASSERT_TRUE(!Verify(Method(mock, func).Using(1)).Never());
 		ASSERT_FALSE(!VerifyNoOtherInvocations(Method(mock, func)));
     }
+
+	void verificationShouldTolerateNullString(){
+		struct RefEater {
+			virtual int eatChar(char*) = 0;
+			virtual int eatConstChar(const char*) = 0;
+		};
+
+		Mock<RefEater> mock;
+		When( Method( mock, eatChar ) ).AlwaysReturn( 0 );
+		When( Method( mock, eatConstChar ) ).AlwaysReturn( 0 );
+
+		RefEater& obj = mock.get();
+		obj.eatConstChar( nullptr );
+		obj.eatChar( nullptr );
+
+		Verify(Method(mock,eatChar)).Exactly(1);
+		Verify(Method(mock,eatConstChar)).Exactly(1);
+		ASSERT_THROW(Verify(Method(mock, eatChar)).Exactly(3), fakeit::VerificationException);
+		ASSERT_THROW(Verify(Method(mock, eatConstChar)).Exactly(3), fakeit::VerificationException);
+	}
 
 } __BasicVerification;

--- a/tests/verification_tests.cpp
+++ b/tests/verification_tests.cpp
@@ -583,10 +583,13 @@ struct BasicVerification: tpunit::TestFixture {
 
 		RefEater& obj = mock.get();
 		obj.eatConstChar( nullptr );
+		obj.eatConstChar( "string" );
 		obj.eatChar( nullptr );
+		char str[] = { 'a', '\0' };
+		obj.eatChar( str );
 
-		Verify(Method(mock,eatChar)).Exactly(1);
-		Verify(Method(mock,eatConstChar)).Exactly(1);
+		Verify(Method(mock,eatChar)).Exactly(2);
+		Verify(Method(mock,eatConstChar)).Exactly(2);
 		ASSERT_THROW(Verify(Method(mock, eatChar)).Exactly(3), fakeit::VerificationException);
 		ASSERT_THROW(Verify(Method(mock, eatConstChar)).Exactly(3), fakeit::VerificationException);
 	}


### PR DESCRIPTION
Fixes #137 

Added a custom formatter for char*, because the is_ostreamable formatter crashes if the value is nullptr.