### PR TITLE
Fix access violation that happens when Mock with destructor has more methods.

### DIFF
--- a/include/mockutils/DynamicProxy.hpp
+++ b/include/mockutils/DynamicProxy.hpp
@@ -43,6 +43,10 @@ namespace fakeit {
                 std::vector<std::shared_ptr<Destructible>> &methodMocks,
                 std::vector<unsigned int> &offsets) :
                 _methodMocks(methodMocks), _offsets(offsets) {
+			for (std::vector<unsigned int>::iterator it = _offsets.begin(); it != _offsets.end(); ++it)
+			{
+				*it = INT_MAX;
+			}
         }
 
         Destructible *getInvocatoinHandlerPtrById(unsigned int id) override {

--- a/tests/dtor_mocking_tests.cpp
+++ b/tests/dtor_mocking_tests.cpp
@@ -22,7 +22,8 @@ struct DtorMocking : tpunit::TestFixture
             TEST(DtorMocking::mock_virtual_dtor_by_assignment),
             TEST(DtorMocking::call_dtor_without_delete),
             TEST(DtorMocking::spy_dtor),
-			TEST(DtorMocking::production_takes_ownwership_with_uniqe_ptr)//
+			TEST(DtorMocking::production_takes_ownwership_with_uniqe_ptr),
+			TEST(DtorMocking::production_takes_ownership_interface_with_more_methods)
 		)
 	{
 	}
@@ -93,5 +94,21 @@ struct DtorMocking : tpunit::TestFixture
         Verify(Dtor(mock)).Twice();
 		ASSERT_THROW(Verify(Dtor(mock)).Once(), fakeit::VerificationException);
     }
+
+	class SomeInterface2 {
+	public:
+		virtual void DoSomething() = 0;
+		virtual ~SomeInterface2() = default;
+	};
+
+	void production_takes_ownership_interface_with_more_methods() {
+		Mock<SomeInterface2> m;
+
+		Fake(Method(m, DoSomething));
+		Fake(Dtor(m));
+
+		std::unique_ptr<SomeInterface2> ptr = std::unique_ptr<SomeInterface2>(&m.get());		
+		ptr = nullptr;
+	}
 
 } __DtorMocking;


### PR DESCRIPTION
If the offsets are all initialised to 0, ocasionally the destructors get the wrong offset.