### PR TITLE
Fix compatibility for Catch 2.2.1 and bug 

### DIFF
--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -1170,9 +1170,9 @@ namespace fakeit {
                 std::string fomattedMessage,
                 Catch::ResultWas::OfType resultWas = Catch::ResultWas::OfType::ExpressionFailed ){
             Catch::AssertionHandler catchAssertionHandler( vetificationType, sourceLineInfo, failingExpression, Catch::ResultDisposition::Normal );
-            INTERNAL_CATCH_TRY( catchAssertionHandler ) { \
+            INTERNAL_CATCH_TRY { \
                 CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
-                catchAssertionHandler.handle( resultWas , fomattedMessage); \
+                catchAssertionHandler.handleMessage( resultWas , fomattedMessage); \
                 CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
             } INTERNAL_CATCH_CATCH( catchAssertionHandler ) \
             INTERNAL_CATCH_REACT( catchAssertionHandler )


### PR DESCRIPTION
"Try not followed by compound statement"

Pull request for issue #124 and fix first proposed by @jlkalberer

See https://en.cppreference.com/w/cpp/language/try_catch