### PR TITLE
Include cassert when using FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION

### DIFF
--- a/include/fakeit/FakeitContext.hpp
+++ b/include/fakeit/FakeitContext.hpp
@@ -11,6 +11,9 @@
 #include <vector>
 #include "fakeit/EventHandler.hpp"
 #include "fakeit/EventFormatter.hpp"
+#ifdef FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION
+#include <cassert>
+#endif
 
 namespace fakeit {
 


### PR DESCRIPTION
If the cassert file was not include by any other header, the tests would not compile when FAKEIT_ASSERT_ON_UNEXPECTED_METHOD_INVOCATION was used