### PR TITLE
#154 adapt to new catch2 include paths

### DIFF
--- a/config/catch/CatchFakeit.hpp
+++ b/config/catch/CatchFakeit.hpp
@@ -3,7 +3,11 @@
 #include "fakeit/DefaultFakeit.hpp"
 #include "fakeit/EventHandler.hpp"
 #include "mockutils/to_string.hpp"
-#include "catch.hpp"
+#if __has_include("catch2/catch.hpp")
+#   include "catch2/catch.hpp"
+#else
+#   include "catch.hpp"
+#endif
 
 namespace fakeit {
 


### PR DESCRIPTION
This PR introduces a preprocessor check for the newer catch2 include path introduced in catch2 2.3.0 as proposed in #154 .

This limits supported compilers to those that support `__has_include`.