### PR TITLE
Add cmake support.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,59 +1,43 @@
-IF(BIICODE)
-  ADD_BII_TARGETS()
-ENDIF()
 
-#LIST(APPEND BII_LIB_SRC tests/argument_matching_tests.cpp)
-###############################################################################
-#      HELP                                                                   #
-###############################################################################
-#
-# This CMakeLists.txt file helps defining your block builds
-# To learn more visit http://docs.biicode.com/c++.html
-#
-# To include published cmake scripts:
-#   1. INCLUDE(user/block/myrecipe) # include myrecipe.cmake from remote user/block
-#   2. Remember to execute bii find
-#   Example:
-#      INCLUDE(biicode/cmake/tools) # Include tools.cmake file from cmake block from "biicode" user
-#      ACTIVATE_CPP11(INTERFACE ${BII_BLOCK_TARGET})
-#
-# Useful variables:
-#   To be modified BEFORE the call to ADD_BII_TARGETS()
-#     ${BII_LIB_SRC}  File list to create the library
-#
-#   To be modified AFTER the call to ADD_BII_TARGETS()
-#     ${BII_BLOCK_TARGET}  Interface (no files) target for convenient configuration of all
-#                          targets in this block, as the rest of targets always depend on it
-#                          has name in the form "user_block_interface"
-#     ${BII_LIB_TARGET}  Target library name, usually in the form "user_block". May not exist
-#                        if BII_LIB_SRC is empty
-#     ${BII_BLOCK_TARGETS} List of all targets defined in this block
-#     ${BII_BLOCK_EXES} List of executables targets defined in this block
-#     ${BII_exe_name_TARGET}: Executable target (e.g. ${BII_main_TARGET}. You can also use
-#                            directly the name of the executable target (e.g. user_block_main)
-#
-# > EXAMPLE: Add include directories to all targets of this block
-#
-#    TARGET_INCLUDE_DIRECTORIES(${BII_BLOCK_TARGET} INTERFACE myincludedir)
-#
-# > EXAMPLE: Link with pthread:
-#
-#    TARGET_LINK_LIBRARIES(${BII_BLOCK_TARGET} INTERFACE pthread)
-#        or link against library:
-#    TARGET_LINK_LIBRARIES(${BII_LIB_TARGET} PUBLIC pthread)
-#
-#    NOTE:  This can be also done adding pthread to ${BII_LIB_DEPS}
-#            BEFORE calling ADD_BIICODE_TARGETS()
-#
-# > EXAMPLE: how to activate C++11
-#
-#    IF(APPLE)
-#         TARGET_COMPILE_OPTIONS(${BII_BLOCK_TARGET} INTERFACE "-std=c++11 -stdlib=libc++")
-#    ELSEIF (WIN32 OR UNIX)
-#         TARGET_COMPILE_OPTIONS(${BII_BLOCK_TARGET} INTERFACE "-std=c++11")
-#    ENDIF(APPLE)
-#
-# > EXAMPLE: Set properties to target
-#
-#    SET_TARGET_PROPERTIES(${BII_BLOCK_TARGET} PROPERTIES COMPILE_DEFINITIONS "IOV_MAX=255")
-#
+cmake_minimum_required(VERSION 3.0)
+
+project(FakeIt VERSION 2.0.5 LANGUAGES CXX)
+
+#Create library with INTERFACE parameter because we want to use headers from outside.
+add_library(FakeIt INTERFACE)
+
+#Add include directories to the interface library.
+#If we use FakeIt from build-tree then we use BUILD_INTERFACE wrapper.
+#If we use FakeIt from install-tree then we use INSTALL_INTERFACE wrapper.
+target_include_directories(FakeIt INTERFACE
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/single_header/standalone>
+    $<INSTALL_INTERFACE:include>
+)
+
+#Add alias for the library with namespace.
+add_library(FakeIt::FakeIt ALIAS FakeIt)
+
+#Install single_header file to install directory to include subdirectory.
+#Trailing slash at "single_header/standalone/" string means that
+#the header will be installed like ${CMAKE_INSTALL_PREFIX}/include/fakeit.hpp
+#instead of ${CMAKE_INSTALL_PREFIX}/include/standalone/fakeit.hpp.
+install(DIRECTORY single_header/standalone/ DESTINATION include)
+
+#Add FakeIt target to the FakeItConfig.cmake file
+#which will be used to find FakeIt from outside.
+install(TARGETS FakeIt EXPORT FakeItConfig)
+
+#Install FakeItConfig.cmake file to the ${CMAKE_INSTALL_PREFIX}/share/FakeIt/cmake directory
+#and all correlated targets should be called from outside by the namespace.
+install(EXPORT FakeItConfig NAMESPACE FakeIt:: DESTINATION share/FakeIt/cmake)
+
+#Add version control.
+include(CMakePackageConfigHelpers)
+write_basic_package_version_file("${PROJECT_BINARY_DIR}/FakeItConfigVersion.cmake"
+    VERSION
+        ${PROJECT_VERSION}
+    COMPATIBILITY
+        AnyNewerVersion
+)
+install(FILES "${PROJECT_BINARY_DIR}/FakeItConfigVersion.cmake" DESTINATION share/FakeIt/cmake)
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,7 @@
 
-cmake_minimum_required(VERSION 3.0)
+#ARCH_INDEPENDENT option at write_basic_package_version_file
+#requires 3.14 version of CMake
+cmake_minimum_required(VERSION 3.14)
 
 project(FakeIt VERSION 2.0.5 LANGUAGES CXX)
 
@@ -41,6 +43,7 @@ write_basic_package_version_file("${PROJECT_BINARY_DIR}/FakeItConfigVersion.cmak
         ${PROJECT_VERSION}
     COMPATIBILITY
         AnyNewerVersion
+    ARCH_INDEPENDENT
 )
 install(FILES "${PROJECT_BINARY_DIR}/FakeItConfigVersion.cmake" DESTINATION share/FakeIt/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 3.0)
 
 project(FakeIt VERSION 2.0.5 LANGUAGES CXX)
 
+#Add GNU Coding Standards support.
+include(GNUInstallDirs)
+
 #Create library with INTERFACE parameter because we want to use headers from outside.
 add_library(FakeIt INTERFACE)
 
@@ -11,7 +14,7 @@ add_library(FakeIt INTERFACE)
 #If we use FakeIt from install-tree then we use INSTALL_INTERFACE wrapper.
 target_include_directories(FakeIt INTERFACE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/single_header/standalone>
-    $<INSTALL_INTERFACE:include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 
 #Add alias for the library with namespace.
@@ -21,7 +24,7 @@ add_library(FakeIt::FakeIt ALIAS FakeIt)
 #Trailing slash at "single_header/standalone/" string means that
 #the header will be installed like ${CMAKE_INSTALL_PREFIX}/include/fakeit.hpp
 #instead of ${CMAKE_INSTALL_PREFIX}/include/standalone/fakeit.hpp.
-install(DIRECTORY single_header/standalone/ DESTINATION include)
+install(DIRECTORY single_header/standalone/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 #Add FakeIt target to the FakeItConfig.cmake file
 #which will be used to find FakeIt from outside.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,9 +32,11 @@ install(DIRECTORY single_header/standalone/ DESTINATION ${CMAKE_INSTALL_INCLUDED
 #which will be used to find FakeIt from outside.
 install(TARGETS FakeIt EXPORT FakeItConfig)
 
-#Install FakeItConfig.cmake file to the ${CMAKE_INSTALL_PREFIX}/share/FakeIt/cmake directory
+set(FakeIt_CONFIG_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/FakeIt)
+
+#Install FakeItConfig.cmake file to the ${CMAKE_INSTALL_PREFIX}/${FakeIt_CONFIG_DIR} directory
 #and all correlated targets should be called from outside by the namespace.
-install(EXPORT FakeItConfig NAMESPACE FakeIt:: DESTINATION share/FakeIt/cmake)
+install(EXPORT FakeItConfig NAMESPACE FakeIt:: DESTINATION ${FakeIt_CONFIG_DIR})
 
 #Add version control.
 include(CMakePackageConfigHelpers)
@@ -45,5 +47,5 @@ write_basic_package_version_file("${PROJECT_BINARY_DIR}/FakeItConfigVersion.cmak
         AnyNewerVersion
     ARCH_INDEPENDENT
 )
-install(FILES "${PROJECT_BINARY_DIR}/FakeItConfigVersion.cmake" DESTINATION share/FakeIt/cmake)
+install(FILES "${PROJECT_BINARY_DIR}/FakeItConfigVersion.cmake" DESTINATION ${FakeIt_CONFIG_DIR})
 


### PR DESCRIPTION
Replace old CMakeLists.txt with the new one.
Now FakeIt can be linked to the project in the following way:
```
find_package(FakeIt)
...
target_link_libraries(a_project
    PRIVATE
        FakeIt::FakeIt
)
```
I found a related [issue](https://github.com/eranpeer/FakeIt/issues/139) with this request.
Also, I create a [repository](https://github.com/libenike/FakeItUsageExample.git) with a simple project which uses FakeIt and a detailed description of building the project.