### PR TITLE
catch v2.11.0

### DIFF
--- a/config/catch/CatchFakeit.hpp
+++ b/config/catch/CatchFakeit.hpp
@@ -92,9 +92,10 @@ namespace fakeit {
                 Catch::ResultWas::OfType resultWas = Catch::ResultWas::OfType::ExpressionFailed ){
             Catch::AssertionHandler catchAssertionHandler( vetificationType, sourceLineInfo, failingExpression, Catch::ResultDisposition::Normal );
             INTERNAL_CATCH_TRY { \
+                CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
                 CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
                 catchAssertionHandler.handleMessage(resultWas, fomattedMessage); \
-                CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
+                CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
             } INTERNAL_CATCH_CATCH(catchAssertionHandler) { \
                 INTERNAL_CATCH_REACT(catchAssertionHandler) \
             }

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2019-06-01 12:14:44.281637
+ *  Generated: 2019-11-19 16:36:52.128738
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -1220,9 +1220,10 @@ namespace fakeit {
                 Catch::ResultWas::OfType resultWas = Catch::ResultWas::OfType::ExpressionFailed ){
             Catch::AssertionHandler catchAssertionHandler( vetificationType, sourceLineInfo, failingExpression, Catch::ResultDisposition::Normal );
             INTERNAL_CATCH_TRY { \
+                CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
                 CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
                 catchAssertionHandler.handleMessage(resultWas, fomattedMessage); \
-                CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
+                CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
             } INTERNAL_CATCH_CATCH(catchAssertionHandler) { \
                 INTERNAL_CATCH_REACT(catchAssertionHandler) \
             }
@@ -9355,7 +9356,7 @@ namespace fakeit {
 #endif
 
 #define MOCK_TYPE(mock) \
-    std::remove_reference<decltype(mock.get())>::type
+    std::remove_reference<decltype((mock).get())>::type
 
 #define OVERLOADED_METHOD_PTR(mock, method, prototype) \
     fakeit::Prototype<prototype>::MemberType<MOCK_TYPE(mock)>::get(&MOCK_TYPE(mock)::method)
@@ -9364,16 +9365,16 @@ namespace fakeit {
     fakeit::Prototype<prototype>::MemberType<MOCK_TYPE(mock)>::getconst(&MOCK_TYPE(mock)::method)
 
 #define Dtor(mock) \
-    mock.dtor().setMethodDetails(#mock,"destructor")
+    (mock).dtor().setMethodDetails(#mock,"destructor")
 
 #define Method(mock, method) \
-    mock.template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
+    (mock).template stub<__COUNTER__>(&MOCK_TYPE(mock)::method).setMethodDetails(#mock,#method)
 
 #define OverloadedMethod(mock, method, prototype) \
-    mock.template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<__COUNTER__>(OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define ConstOverloadedMethod(mock, method, prototype) \
-    mock.template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+    (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)


### PR DESCRIPTION
Updated catch2 port regarding to changes in catch2 v 2.11.0. Catch2 internal macros were changed and that changes are ported here as follows:
 - removed macro CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS
 - added macros CATCH_INTERNAL_START_WARNINGS_SUPPRESSION and CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION

