### PR TITLE
Add Any verification specifier

### DIFF
--- a/include/fakeit/SequenceVerificationExpectation.hpp
+++ b/include/fakeit/SequenceVerificationExpectation.hpp
@@ -27,6 +27,10 @@ namespace fakeit {
             _expectedCount = count;
         }
 
+        void expectAnything() {
+            _expectAnything = true;
+        }
+
         void setFileInfo(const char * file, int line, const char * callingMethod) {
             _file = file;
             _line = line;
@@ -39,6 +43,7 @@ namespace fakeit {
         InvocationsSourceProxy _involvedInvocationSources;
         std::vector<Sequence *> _expectedPattern;
         int _expectedCount;
+        bool _expectAnything;
 
         const char * _file;
         int _line;
@@ -53,6 +58,7 @@ namespace fakeit {
                 _involvedInvocationSources(mocks),
                 _expectedPattern(expectedPattern), //
                 _expectedCount(-1), // AT_LEAST_ONCE
+                _expectAnything(false),
                 _line(0),
                 _isVerified(false) {
         }
@@ -66,12 +72,14 @@ namespace fakeit {
             MatchAnalysis ma;
             ma.run(_involvedInvocationSources, _expectedPattern);
 
-            if (isAtLeastVerification() && atLeastLimitNotReached(ma.count)) {
-                return handleAtLeastVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
-            }
+            if (isNotAnythingVerification()) {
+                if (isAtLeastVerification() && atLeastLimitNotReached(ma.count)) {
+                    return handleAtLeastVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+                }
 
-            if (isExactVerification() && exactLimitNotMatched(ma.count)) {
-                return handleExactVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+                if (isExactVerification() && exactLimitNotMatched(ma.count)) {
+                    return handleExactVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+                }
             }
 
             markAsVerified(ma.matchedInvocations);
@@ -102,6 +110,10 @@ namespace fakeit {
 
         bool isExactVerification() {
             return !isAtLeastVerification();
+        }
+
+        bool isNotAnythingVerification() {
+            return !_expectAnything;
         }
 
         bool atLeastLimitNotReached(int actualCount) {

--- a/include/fakeit/SequenceVerificationProgress.hpp
+++ b/include/fakeit/SequenceVerificationProgress.hpp
@@ -75,6 +75,11 @@ namespace fakeit {
             return Terminator(_expectationPtr);
         }
 
+        Terminator Any() {
+            _expectationPtr->expectAnything();
+            return Terminator(_expectationPtr);
+        }
+
         Terminator Once() {
             Exactly(1);
             return Terminator(_expectationPtr);


### PR DESCRIPTION
A flexible test may want to ignore invocations of trivial methods, like
getters and read only functions. Such methods may be called any number
of times, including none.

Currently FakeIt has no way to discard the invocations of a sequence of
methods. Using `ClearInvocationHistory` would discard all the methods,
trivial or not.

This new verification specifier, `Any`, marks a method or sequence
of methods as verified, regardless of the number of invocations
(including none).

Example:

    Verify(Method(mock, important_method)).Exactly(3);
    Verify(Method(mock, trivial_getter)).Any();
    VerifyNoOtherInvocations(mock);

Using this modifier, a flexible test may white-list the trivial methods,
and make sure that important methods are not called.