### PR TITLE
Catch 2.11.0 support

### DIFF
--- a/config/catch/CatchFakeit.hpp
+++ b/config/catch/CatchFakeit.hpp
@@ -92,9 +92,10 @@ namespace fakeit {
                 Catch::ResultWas::OfType resultWas = Catch::ResultWas::OfType::ExpressionFailed ){
             Catch::AssertionHandler catchAssertionHandler( vetificationType, sourceLineInfo, failingExpression, Catch::ResultDisposition::Normal );
             INTERNAL_CATCH_TRY { \
+                CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
                 CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
                 catchAssertionHandler.handleMessage(resultWas, fomattedMessage); \
-                CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
+                CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
             } INTERNAL_CATCH_CATCH(catchAssertionHandler) { \
                 INTERNAL_CATCH_REACT(catchAssertionHandler) \
             }

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -1220,9 +1220,10 @@ namespace fakeit {
                 Catch::ResultWas::OfType resultWas = Catch::ResultWas::OfType::ExpressionFailed ){
             Catch::AssertionHandler catchAssertionHandler( vetificationType, sourceLineInfo, failingExpression, Catch::ResultDisposition::Normal );
             INTERNAL_CATCH_TRY { \
+                CATCH_INTERNAL_START_WARNINGS_SUPPRESSION \
                 CATCH_INTERNAL_SUPPRESS_PARENTHESES_WARNINGS \
                 catchAssertionHandler.handleMessage(resultWas, fomattedMessage); \
-                CATCH_INTERNAL_UNSUPPRESS_PARENTHESES_WARNINGS \
+                CATCH_INTERNAL_STOP_WARNINGS_SUPPRESSION \
             } INTERNAL_CATCH_CATCH(catchAssertionHandler) { \
                 INTERNAL_CATCH_REACT(catchAssertionHandler) \
             }


### PR DESCRIPTION
FakeIt won't compile wth Catch 2.11.0. This PR fixes the problem.

Resolves #197.