### PR TITLE
Add ReturnAndSet() & AlwaysReturnAndSet() functions to assign output args

### DIFF
--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -148,7 +148,12 @@ namespace fakeit {
         MethodStubbingProgress &operator=(const MethodStubbingProgress &other) = delete;
 
         template<typename ... valuelist>
-        auto GetAssigner(R &&r, valuelist &&... arg_vals) {
+#if __cplusplus >= 201402L
+        auto
+#else
+        std::function<R (const typename fakeit::test_arg<arglist>::type...)>
+#endif
+        GetAssigner(R &&r, valuelist &&... arg_vals) {
             return
                 [vals_tuple = ArgumentsTuple<R, valuelist...>{
                     std::forward<R>(r), std::forward<valuelist>(arg_vals)...}
@@ -252,7 +257,12 @@ namespace fakeit {
         MethodStubbingProgress &operator=(const MethodStubbingProgress &other) = delete;
 
         template<typename ... valuelist>
-        auto GetAssigner(valuelist &&... arg_vals) {
+#if __cplusplus >= 201402L
+        auto
+#else
+        std::function<void (typename fakeit::test_arg<arglist>::type...)>
+#endif
+        GetAssigner(valuelist &&... arg_vals) {
             return
                 [vals_tuple = ArgumentsTuple<valuelist...>{
                     std::forward<valuelist>(arg_vals)...}
@@ -268,17 +278,17 @@ namespace fakeit {
     template<int N>
     struct Assigner {
         template<typename current_arg, typename ... valuelist, typename ... arglist>
-        static typename std::enable_if<!std::is_pointer_v<current_arg>, void>::type
+        static typename std::enable_if<!std::is_pointer<current_arg>::value, void>::type
         Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&t, arglist&&... args) {
             Assigner<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
-            t = std::get<std::tuple_size_v<ArgumentsTuple<valuelist...>> - N>(arg_vals);
+            t = std::get<std::tuple_size<ArgumentsTuple<valuelist...>>::value - N>(arg_vals);
         }
 
         template<typename current_arg, typename ... valuelist, typename ... arglist>
-        static typename std::enable_if<std::is_pointer_v<current_arg>, void>::type
+        static typename std::enable_if<std::is_pointer<current_arg>::value, void>::type
         Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&t, arglist&&... args) {
             Assigner<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
-            *t = std::get<std::tuple_size_v<ArgumentsTuple<valuelist...>> - N>(arg_vals);
+            *t = std::get<std::tuple_size<ArgumentsTuple<valuelist...>>::value - N>(arg_vals);
         }
     };
 

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -23,8 +23,23 @@
 
 namespace fakeit {
 
-    template<int N>
-    struct Assigner;
+    namespace helper
+    {
+        template <typename T, int N>
+        struct ArgValue;
+
+        template <int max_index, int tuple_index>
+        struct ArgValidator;
+
+        template<int arg_index, typename current_arg, typename ...T, int ...N, typename ... arglist>
+        static void
+        Assign(std::tuple<ArgValue<T, N>...> arg_vals, current_arg &&p, arglist &&... args);
+
+        template<int N>
+        struct ParamWalker;
+
+    }  // namespace helper
+
 
     template<typename R, typename ... arglist>
     struct MethodStubbingProgress {
@@ -151,19 +166,39 @@ namespace fakeit {
 #if __cplusplus >= 201402L
         auto
 #else
-        std::function<R (const typename fakeit::test_arg<arglist>::type...)>
+        std::function<R (typename fakeit::test_arg<arglist>::type...)>
 #endif
         GetAssigner(R &&r, valuelist &&... arg_vals) {
             return
                 [vals_tuple = ArgumentsTuple<R, valuelist...>{
                     std::forward<R>(r), std::forward<valuelist>(arg_vals)...}
-                ] (const typename fakeit::test_arg<arglist>::type...args)
+                ] (typename fakeit::test_arg<arglist>::type...args)
                 {
-                    Assigner<sizeof...(valuelist)>::Assign(vals_tuple,
+                    helper::ParamWalker<sizeof...(valuelist)>::Assign(vals_tuple,
                         std::forward<arglist>(args)...);
                     return std::get<0>(vals_tuple);
                 };
         }
+
+        template<typename ...T, int ...N>
+#if __cplusplus >= 201402L
+        auto
+#else
+        std::function<R (typename fakeit::test_arg<arglist>::type...)>
+#endif
+        GetAssigner(R &&r, helper::ArgValue<T, N>... arg_vals) {
+            return
+                [ret = std::tuple<R>{ std::forward<R>(r) },
+                 vals_tuple = ArgumentsTuple<helper::ArgValue<T, N>...>{
+                    std::forward<helper::ArgValue<T, N>>(arg_vals)...}
+                ] (typename fakeit::test_arg<arglist>::type...args) -> R
+                {
+                    helper::ArgValidator<sizeof...(arglist), sizeof...(T) - 1>::CheckPositions(vals_tuple);
+                    helper::Assign<1>(vals_tuple, std::forward<arglist>(args)...);
+                    return std::get<0>(ret);
+                };
+        }
+
     };
 
 
@@ -266,36 +301,143 @@ namespace fakeit {
             return
                 [vals_tuple = ArgumentsTuple<valuelist...>{
                     std::forward<valuelist>(arg_vals)...}
-                ] (const typename fakeit::test_arg<arglist>::type...args)
+                ] (typename fakeit::test_arg<arglist>::type...args)
                 {
-                    Assigner<sizeof...(valuelist)>::Assign(vals_tuple,
+                    helper::ParamWalker<sizeof...(valuelist)>::Assign(vals_tuple,
                         std::forward<arglist>(args)...);
                 };
         }
-    };
 
-
-    template<int N>
-    struct Assigner {
-        template<typename current_arg, typename ... valuelist, typename ... arglist>
-        static typename std::enable_if<!std::is_pointer<current_arg>::value, void>::type
-        Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&t, arglist&&... args) {
-            Assigner<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
-            t = std::get<std::tuple_size<ArgumentsTuple<valuelist...>>::value - N>(arg_vals);
+        template<typename ...T, int ...N>
+#if __cplusplus >= 201402L
+        auto
+#else
+        std::function<void (typename fakeit::test_arg<arglist>::type...)>
+#endif
+        GetAssigner(helper::ArgValue<T, N>... arg_vals) {
+            return
+                [vals_tuple = ArgumentsTuple<helper::ArgValue<T, N>...>{
+                    std::forward<helper::ArgValue<T, N>>(arg_vals)...}
+                ] (typename fakeit::test_arg<arglist>::type...args)
+                {
+                    helper::ArgValidator<sizeof...(arglist), sizeof...(T) - 1>::CheckPositions(vals_tuple);
+                    helper::Assign<1>(vals_tuple, std::forward<arglist>(args)...);
+                };
         }
 
-        template<typename current_arg, typename ... valuelist, typename ... arglist>
-        static typename std::enable_if<std::is_pointer<current_arg>::value, void>::type
-        Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&t, arglist&&... args) {
-            Assigner<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
-            *t = std::get<std::tuple_size<ArgumentsTuple<valuelist...>>::value - N>(arg_vals);
+    };
+
+
+    namespace helper
+    {
+        template <typename T, int N>
+        struct ArgValue
+        {
+            ArgValue(T &&v): value { std::forward<T>(v) } {}
+            constexpr static int pos = N;
+            T value;
+        };
+
+        template <int max_index, int tuple_index>
+        struct ArgValidator
+        {
+            template <typename ...T, int ...N>
+            static void CheckPositions(const std::tuple<ArgValue<T, N>...> arg_vals)
+            {
+#if __cplusplus >= 201402L
+                static_assert(std::get<tuple_index>(arg_vals).pos <= max_index,
+                    "Argument index out of range");
+                ArgValidator<max_index, tuple_index - 1>::CheckPositions(arg_vals);
+#endif
+            }
+        };
+
+        template <int max_index>
+        struct ArgValidator<max_index, -1>
+        {
+            template <typename T>
+            static void CheckPositions(T) {}
+        };
+
+        template <typename current_arg>
+        typename std::enable_if<std::is_pointer<current_arg>::value,
+            typename std::remove_pointer<current_arg>::type &>::type
+        GetArg(current_arg &&t)
+        {
+            return *t;
         }
-    };
 
-    template<>
-    struct Assigner<0> {
-        template<typename ... valuelist, typename ... arglist>
-        static void Assign(ArgumentsTuple<valuelist...>, arglist... ) {}
-    };
+        template <typename current_arg>
+        typename std::enable_if<!std::is_pointer<current_arg>::value, current_arg>::type
+        GetArg(current_arg &&t)
+        {
+            return std::forward<current_arg>(t);
+        }
 
+        template<int N>
+        struct ParamWalker {
+            template<typename current_arg, typename ... valuelist, typename ... arglist>
+            static void
+            Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&p, arglist&&... args) {
+                ParamWalker<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+                GetArg(std::forward<current_arg>(p)) = std::get<sizeof...(valuelist) - N>(arg_vals);
+            }
+        };
+
+        template<>
+        struct ParamWalker<0> {
+            template<typename ... valuelist, typename ... arglist>
+            static void Assign(ArgumentsTuple<valuelist...>, arglist... ) {}
+        };
+
+        template<int arg_index, int check_index>
+        struct ArgLocator {
+            template<typename current_arg, typename ...T, int ...N>
+            static void AssignArg(current_arg &&p, std::tuple<ArgValue<T, N>...> arg_vals) {
+                if (std::get<check_index>(arg_vals).pos == arg_index)
+                    GetArg(std::forward<current_arg>(p)) = std::get<check_index>(arg_vals).value;
+                else if (check_index > 0)
+                    ArgLocator<arg_index, check_index - 1>::AssignArg(std::forward<current_arg>(p), arg_vals);
+            }
+        };
+
+        template<int arg_index>
+        struct ArgLocator<arg_index, -1> {
+            template<typename current_arg, typename T>
+            static void AssignArg(current_arg, T) {
+            }
+        };
+
+        template<int arg_index, typename current_arg, typename ...T, int ...N, typename ... arglist>
+        static void
+        Assign(std::tuple<ArgValue<T, N>...> arg_vals, current_arg &&p, arglist &&... args) {
+            ArgLocator<arg_index, sizeof...(N) - 1>::AssignArg(std::forward<current_arg>(p), arg_vals);
+            Assign<arg_index + 1>(arg_vals, std::forward<arglist>(args)...);
+        }
+
+        template<int arg_index,  typename ... valuelist>
+        static void Assign(std::tuple<valuelist...>) {}
+
+    }  // namespace helper
+
+    /*
+     * Users might use our placeholders so that our operator<= is automatically
+     * picked up using ADL. They might use std placeholders instead, but they
+     * should make our operator<= from fakeit namespace visible to their code.
+     */
+    namespace placeholders
+    {
+        using namespace std::placeholders;
+
+        template <typename PlaceHolder, typename ArgType,
+            typename std::enable_if<static_cast<bool>(std::is_placeholder<PlaceHolder>::value), bool>::type = true>
+        helper::ArgValue<ArgType, std::is_placeholder<PlaceHolder>::value>
+        operator<=(PlaceHolder, ArgType &&arg)
+        {
+            return { std::forward<ArgType>(arg) };
+        }
+
+    }  // namespace placeholders
+
+    using placeholders::operator <=;
 }

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -23,6 +23,9 @@
 
 namespace fakeit {
 
+    template<int N>
+    struct Assigner;
+
     template<typename R, typename ... arglist>
     struct MethodStubbingProgress {
 
@@ -102,6 +105,19 @@ namespace fakeit {
             return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> R { throw e; });
         }
 
+        template<typename ... valuelist>
+        MethodStubbingProgress<R, arglist...> &
+        Set(R &&r, valuelist &&... arg_vals) {
+            return Do(GetAssigner(std::forward<R>(r),
+                    std::forward<valuelist>(arg_vals)...));
+        }
+
+        template<typename ... valuelist>
+        void AlwaysSet(R &&r, valuelist &&... arg_vals) {
+            AlwaysDo(GetAssigner(std::forward<R>(r),
+                std::forward<valuelist>(arg_vals)...));
+        }
+
         virtual MethodStubbingProgress<R, arglist...> &
             Do(std::function<R(const typename fakeit::test_arg<arglist>::type...)> method) {
             return DoImpl(new Repeat<R, arglist...>(method));
@@ -130,6 +146,19 @@ namespace fakeit {
 
     private:
         MethodStubbingProgress &operator=(const MethodStubbingProgress &other) = delete;
+
+        template<typename ... valuelist>
+        auto GetAssigner(R &&r, valuelist &&... arg_vals) {
+            return
+                [vals_tuple = ArgumentsTuple<R, valuelist...>{
+                    std::forward<R>(r), std::forward<valuelist>(arg_vals)...}
+                ] (const typename fakeit::test_arg<arglist>::type...args)
+                {
+                    Assigner<sizeof...(valuelist)>::Assign(vals_tuple,
+                        std::forward<arglist>(args)...);
+                    return std::get<0>(vals_tuple);
+                };
+        }
     };
 
 
@@ -187,7 +216,18 @@ namespace fakeit {
             return AlwaysDo([e](const typename fakeit::test_arg<arglist>::type...) -> void { throw e; });
         }
 
-           template<typename F>
+        template<typename ... valuelist>
+        MethodStubbingProgress<void, arglist...> &
+        Set(valuelist &&... arg_vals) {
+            return Do(GetAssigner(std::forward<valuelist>(arg_vals)...));
+        }
+
+        template<typename ... valuelist>
+        void AlwaysSet(valuelist &&... arg_vals) {
+            AlwaysDo(GetAssigner(std::forward<valuelist>(arg_vals)...));
+        }
+
+        template<typename F>
         MethodStubbingProgress<void, arglist...> &
         Do(const Quantifier<F> &q) {
             return DoImpl(new Repeat<void, arglist...>(q.value, q.quantity));
@@ -210,7 +250,42 @@ namespace fakeit {
 
     private:
         MethodStubbingProgress &operator=(const MethodStubbingProgress &other) = delete;
+
+        template<typename ... valuelist>
+        auto GetAssigner(valuelist &&... arg_vals) {
+            return
+                [vals_tuple = ArgumentsTuple<valuelist...>{
+                    std::forward<valuelist>(arg_vals)...}
+                ] (const typename fakeit::test_arg<arglist>::type...args)
+                {
+                    Assigner<sizeof...(valuelist)>::Assign(vals_tuple,
+                        std::forward<arglist>(args)...);
+                };
+        }
     };
 
+
+    template<int N>
+    struct Assigner {
+        template<typename current_arg, typename ... valuelist, typename ... arglist>
+        static typename std::enable_if<!std::is_pointer_v<current_arg>, void>::type
+        Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&t, arglist&&... args) {
+            Assigner<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+            t = std::get<std::tuple_size_v<ArgumentsTuple<valuelist...>> - N>(arg_vals);
+        }
+
+        template<typename current_arg, typename ... valuelist, typename ... arglist>
+        static typename std::enable_if<std::is_pointer_v<current_arg>, void>::type
+        Assign(ArgumentsTuple<valuelist...> arg_vals, current_arg &&t, arglist&&... args) {
+            Assigner<N - 1>::template Assign(arg_vals, std::forward<arglist>(args)...);
+            *t = std::get<std::tuple_size_v<ArgumentsTuple<valuelist...>> - N>(arg_vals);
+        }
+    };
+
+    template<>
+    struct Assigner<0> {
+        template<typename ... valuelist, typename ... arglist>
+        static void Assign(ArgumentsTuple<valuelist...>, arglist... ) {}
+    };
 
 }

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -107,13 +107,13 @@ namespace fakeit {
 
         template<typename ... valuelist>
         MethodStubbingProgress<R, arglist...> &
-        Set(R &&r, valuelist &&... arg_vals) {
+        ReturnAndSet(R &&r, valuelist &&... arg_vals) {
             return Do(GetAssigner(std::forward<R>(r),
                     std::forward<valuelist>(arg_vals)...));
         }
 
         template<typename ... valuelist>
-        void AlwaysSet(R &&r, valuelist &&... arg_vals) {
+        void AlwaysReturnAndSet(R &&r, valuelist &&... arg_vals) {
             AlwaysDo(GetAssigner(std::forward<R>(r),
                 std::forward<valuelist>(arg_vals)...));
         }
@@ -175,7 +175,7 @@ namespace fakeit {
 
         MethodStubbingProgress<void, arglist...> &Return() {
             auto lambda = [](const typename fakeit::test_arg<arglist>::type...) -> void {
-                return DefaultValue<void>::value(); 
+                return DefaultValue<void>::value();
             };
             return Do(lambda);
         }
@@ -223,12 +223,12 @@ namespace fakeit {
 
         template<typename ... valuelist>
         MethodStubbingProgress<void, arglist...> &
-        Set(valuelist &&... arg_vals) {
+        ReturnAndSet(valuelist &&... arg_vals) {
             return Do(GetAssigner(std::forward<valuelist>(arg_vals)...));
         }
 
         template<typename ... valuelist>
-        void AlwaysSet(valuelist &&... arg_vals) {
+        void AlwaysReturnAndSet(valuelist &&... arg_vals) {
             AlwaysDo(GetAssigner(std::forward<valuelist>(arg_vals)...));
         }
 

--- a/tests/stubbing_tests.cpp
+++ b/tests/stubbing_tests.cpp
@@ -48,7 +48,7 @@ struct BasicStubbing : tpunit::TestFixture {
                     TEST(BasicStubbing::stub_multiple_do_with_list),
                     TEST(BasicStubbing::exception_while_stubbing_should_cancel_stubbing),
                     TEST(BasicStubbing::reset_mock_to_initial_state),
-                    TEST(BasicStubbing::use_lambda_to_change_ptr_value), 
+                    TEST(BasicStubbing::use_lambda_to_change_ptr_value),
                     TEST(BasicStubbing::assingOutParamsWithLambda)
             ) {
     }
@@ -128,8 +128,8 @@ struct BasicStubbing : tpunit::TestFixture {
 
     void stub_a_function_to_set_specified_values_once() {
         Mock<SomeInterface> mock;
-        When(Method(mock, funcRefArgs)).Set(1, 2, 3);
-        When(Method(mock, procRefArgs)).Set(4, 5).Set(6, 7);
+        When(Method(mock, funcRefArgs)).ReturnAndSet(1, 2, 3);
+        When(Method(mock, procRefArgs)).ReturnAndSet(4, 5).ReturnAndSet(6, 7);
 
         SomeInterface &i = mock.get();
 
@@ -159,8 +159,8 @@ struct BasicStubbing : tpunit::TestFixture {
     void stub_a_function_to_set_specified_values_always() {
         Mock<SomeInterface> mock;
 
-        When(Method(mock, funcRefArgs)).AlwaysSet(1, 2, 3);
-        When(Method(mock, procRefArgs)).AlwaysSet(4, 5);
+        When(Method(mock, funcRefArgs)).AlwaysReturnAndSet(1, 2, 3);
+        When(Method(mock, procRefArgs)).AlwaysReturnAndSet(4, 5);
 
         SomeInterface &i = mock.get();
 
@@ -228,7 +228,7 @@ struct BasicStubbing : tpunit::TestFixture {
 
         ASSERT_THROW(i.func(3), fakeit::UnexpectedMethodCallException);
         ASSERT_THROW(i.proc(3), fakeit::UnexpectedMethodCallException);
-	
+
 		When(Method(mock, func)).Do([](int& val) {
 			return val + 1;
 		});
@@ -347,7 +347,7 @@ struct BasicStubbing : tpunit::TestFixture {
         i.proc(3);
         i.proc(3);
         ASSERT_EQUAL(3, a);
-    
+
 		Method(mock, func) = [](int& val) {
 			return val + 1;
 		};

--- a/tests/tpunit++.hpp
+++ b/tests/tpunit++.hpp
@@ -241,7 +241,8 @@ public:
 			method* m8 = 0, method* m9 = 0, method* m10 = 0, method* m11 = 0, method* m12 = 0, method* m13 = 0, method* m14 = 0,
 			method* m15 = 0, method* m16 = 0, method* m17 = 0, method* m18 = 0, method* m19 = 0, method* m20 = 0, method* m21 = 0,
 			method* m22 = 0, method* m23 = 0, method* m24 = 0, method* m25 = 0, method* m26 = 0, method* m27 = 0, method* m28 = 0,
-			method* m29 = 0) {
+			method* m29 = 0, method* m30 = 0, method* m31 = 0, method* m32 = 0, method* m33 = 0, method* m34 = 0, method* m35 = 0,
+			method* m36 = 0, method* m37 = 0, method* m38 = 0, method* m39 = 0) {
 		fixture* f = &__fixtures();
 		while (f->_next) {
 			f = f->_next;
@@ -293,6 +294,16 @@ public:
 		SET_FIXTURE_METHOD(m27)
 		SET_FIXTURE_METHOD(m28)
 		SET_FIXTURE_METHOD(m29)
+		SET_FIXTURE_METHOD(m30)
+		SET_FIXTURE_METHOD(m31)
+		SET_FIXTURE_METHOD(m32)
+		SET_FIXTURE_METHOD(m33)
+		SET_FIXTURE_METHOD(m34)
+		SET_FIXTURE_METHOD(m35)
+		SET_FIXTURE_METHOD(m36)
+		SET_FIXTURE_METHOD(m37)
+		SET_FIXTURE_METHOD(m38)
+		SET_FIXTURE_METHOD(m39)
 #undef SET_FIXTURE_METHOD
 	}
 


### PR DESCRIPTION
Add new functions to MethodStubbingProgress, so that output args can be set in addition to return value for a function
