### PR TITLE
Perfectly forward callbacks instead of by-copy

### DIFF
--- a/include/mockutils/TupleDispatcher.hpp
+++ b/include/mockutils/TupleDispatcher.hpp
@@ -13,31 +13,31 @@ namespace fakeit {
 
     template<int N>
     struct apply_func {
-        template<typename R, typename ... ArgsF, typename ... ArgsT, typename ... Args>
-        static R applyTuple(std::function<R(ArgsF &...)> f, std::tuple<ArgsT...> &t, Args &... args) {
-            return apply_func<N - 1>::template applyTuple(f, t, std::get<N - 1>(t), args...);
+        template<typename R, typename ... ArgsF, typename ... ArgsT, typename ... Args, typename FunctionType>
+        static R applyTuple(FunctionType&& f, std::tuple<ArgsT...> &t, Args &... args) {
+            return apply_func<N - 1>::template applyTuple<R>(std::forward<FunctionType>(f), t, std::get<N - 1>(t), args...);
         }
     };
 
     template<>
     struct apply_func < 0 > {
-        template<typename R, typename ... ArgsF, typename ... ArgsT, typename ... Args>
-        static R applyTuple(std::function<R(ArgsF &...)> f, std::tuple<ArgsT...> & /* t */, Args &... args) {
-            return f(args...);
+        template<typename R, typename ... ArgsF, typename ... ArgsT, typename ... Args, typename FunctionType>
+        static R applyTuple(FunctionType&& f, std::tuple<ArgsT...> & /* t */, Args &... args) {
+            return std::forward<FunctionType>(f)(args...);
         }
     };
 
     struct TupleDispatcher {
 
-        template<typename R, typename ... ArgsF, typename ... ArgsT>
-        static R applyTuple(std::function<R(ArgsF &...)> f, std::tuple<ArgsT...> &t) {
-            return apply_func<sizeof...(ArgsT)>::template applyTuple(f, t);
+        template<typename R, typename ... ArgsF, typename ... ArgsT, typename FunctionType>
+        static R applyTuple(FunctionType&& f, std::tuple<ArgsT...> &t) {
+            return apply_func<sizeof...(ArgsT)>::template applyTuple<R>(std::forward<FunctionType>(f), t);
         }
 
-        template<typename R, typename ...arglist>
-        static R invoke(std::function<R(arglist &...)> func, const std::tuple<arglist...> &arguments) {
+        template<typename R, typename ...arglist, typename FunctionType>
+        static R invoke(FunctionType&& func, const std::tuple<arglist...> &arguments) {
             std::tuple<arglist...> &args = const_cast<std::tuple<arglist...> &>(arguments);
-            return applyTuple(func, args);
+            return applyTuple<R>(std::forward<FunctionType>(func), args);
         }
 
         template<typename TupleType, typename FunctionType>

--- a/tests/stubbing_tests.cpp
+++ b/tests/stubbing_tests.cpp
@@ -26,6 +26,7 @@ struct BasicStubbing : tpunit::TestFixture {
                     TEST(BasicStubbing::stub_a_method_to_throw_a_specified_exception_once),//
                     TEST(BasicStubbing::stub_a_method_with_lambda_delegate_once),//
                     TEST(BasicStubbing::stub_a_method_with_lambda_delegate_always),//
+                    TEST(BasicStubbing::stub_a_method_with_mutable_lambda_delegate_always),//
                     TEST(BasicStubbing::stub_a_method_with_static_method_delegate),//
                     TEST(BasicStubbing::stub_by_assignment_with_lambda_delegate),//
                     TEST(BasicStubbing::stub_by_assignment_with_static_method_delegate),//
@@ -52,6 +53,7 @@ struct BasicStubbing : tpunit::TestFixture {
 
     struct SomeInterface {
         virtual int func(int) = 0;
+        virtual int funcNoArgs() = 0;
 
         virtual void proc(int) = 0;
     };
@@ -223,6 +225,19 @@ struct BasicStubbing : tpunit::TestFixture {
 		i.proc(3);
 		ASSERT_EQUAL(3 + 1, a);
 	}
+
+    void stub_a_method_with_mutable_lambda_delegate_always() {
+        Mock<SomeInterface> mock;
+
+        When(Method(mock, funcNoArgs)).AlwaysDo([mutableVar = 0]() mutable {
+            return ++mutableVar;
+        });
+
+        SomeInterface& i = mock.get();
+
+        ASSERT_EQUAL(1, i.funcNoArgs());
+        ASSERT_EQUAL(2, i.funcNoArgs());
+    }
 
     static int func_delegate(int val) {
         return val;


### PR DESCRIPTION
In `TupleDispatcher.hpp`, use perfect forwarding when invoking callbacks instead of always passing by value (makes mutable lambdas work as expected).

Added new test for mutable lambda which passes with fix, and fails without.

All tests pass on GCC & MSVC.