### PR TITLE
Fix std::uncaught_exceptions detection on MSVC.

### DIFF
--- a/include/fakeit/FakeitExceptions.hpp
+++ b/include/fakeit/FakeitExceptions.hpp
@@ -12,7 +12,7 @@
 
 
 namespace fakeit {
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L || defined(__cpp_lib_uncaught_exceptions)
     inline bool UncaughtException () {
         return std::uncaught_exceptions() >= 1;
     }


### PR DESCRIPTION
Check if the macro `__cpp_lib_uncaught_exceptions` is available as well because some compilers like MSVC report an old `__cplusplus` version even in C++17 mode.