### PR TITLE
Remove extra template qualifiers for Times ctor

### DIFF
--- a/include/fakeit/Quantifier.hpp
+++ b/include/fakeit/Quantifier.hpp
@@ -50,7 +50,7 @@ namespace fakeit {
     template<int q>
     struct Times : public Quantity {
 
-        Times<q>() : Quantity(q) { }
+        Times() : Quantity(q) { }
 
         template<typename R>
         static Quantifier<R> of(const R &value) {


### PR DESCRIPTION
This PR fixes a compile error with GCC 11.1 and also uses namespace name in 