### PR TITLE
Add Any verification specifier

### DIFF
--- a/include/fakeit/SequenceVerificationExpectation.hpp
+++ b/include/fakeit/SequenceVerificationExpectation.hpp
@@ -27,6 +27,10 @@ namespace fakeit {
             _expectedCount = count;
         }
 
+        void expectAnything() {
+            _expectAnything = true;
+        }
+
         void setFileInfo(const char * file, int line, const char * callingMethod) {
             _file = file;
             _line = line;
@@ -39,6 +43,7 @@ namespace fakeit {
         InvocationsSourceProxy _involvedInvocationSources;
         std::vector<Sequence *> _expectedPattern;
         int _expectedCount;
+        bool _expectAnything;
 
         const char * _file;
         int _line;
@@ -53,6 +58,7 @@ namespace fakeit {
                 _involvedInvocationSources(mocks),
                 _expectedPattern(expectedPattern), //
                 _expectedCount(-1), // AT_LEAST_ONCE
+                _expectAnything(false),
                 _line(0),
                 _isVerified(false) {
         }
@@ -66,12 +72,14 @@ namespace fakeit {
             MatchAnalysis ma;
             ma.run(_involvedInvocationSources, _expectedPattern);
 
-            if (isAtLeastVerification() && atLeastLimitNotReached(ma.count)) {
-                return handleAtLeastVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
-            }
+            if (isNotAnythingVerification()) {
+                if (isAtLeastVerification() && atLeastLimitNotReached(ma.count)) {
+                    return handleAtLeastVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+                }
 
-            if (isExactVerification() && exactLimitNotMatched(ma.count)) {
-                return handleExactVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+                if (isExactVerification() && exactLimitNotMatched(ma.count)) {
+                    return handleExactVerificationEvent(verificationErrorHandler, ma.actualSequence, ma.count);
+                }
             }
 
             markAsVerified(ma.matchedInvocations);
@@ -93,6 +101,10 @@ namespace fakeit {
             for (auto i : matchedInvocations) {
                 i->markAsVerified();
             }
+        }
+
+        bool isNotAnythingVerification() {
+            return !_expectAnything;
         }
 
         bool isAtLeastVerification() {

--- a/include/fakeit/SequenceVerificationProgress.hpp
+++ b/include/fakeit/SequenceVerificationProgress.hpp
@@ -70,6 +70,11 @@ namespace fakeit {
 
         bool operator!() const { return !Terminator(_expectationPtr); }
 
+        Terminator Any() {
+            _expectationPtr->expectAnything();
+            return Terminator(_expectationPtr);
+        }
+
         Terminator Never() {
             Exactly(0);
             return Terminator(_expectationPtr);

--- a/tests/verification_tests.cpp
+++ b/tests/verification_tests.cpp
@@ -64,7 +64,10 @@ struct BasicVerification: tpunit::TestFixture {
 					TEST(BasicVerification::verify_after_paramter_was_changed_with_argument_matcher), //
 					TEST(BasicVerification::verify_no_invocations),
 					TEST(BasicVerification::verify_after_paramter_was_changed_with_Using), //
-					TEST(BasicVerification::verificationShouldTolerateNullString))
+					TEST(BasicVerification::verificationShouldTolerateNullString),
+					TEST(BasicVerification::verify_any_for_no_invocations),
+					TEST(BasicVerification::verify_any_for_all_invocations),
+					TEST(BasicVerification::verify_any_for_only_some_invocations))
 	{
 	}
 
@@ -592,6 +595,36 @@ struct BasicVerification: tpunit::TestFixture {
 		Verify(Method(mock,eatConstChar)).Exactly(2);
 		ASSERT_THROW(Verify(Method(mock, eatChar)).Exactly(3), fakeit::VerificationException);
 		ASSERT_THROW(Verify(Method(mock, eatConstChar)).Exactly(3), fakeit::VerificationException);
+	}
+
+	void verify_any_for_no_invocations()
+	{
+		Mock<SomeInterface> mock;
+		Verify(Method(mock, func)).Any();
+		VerifyNoOtherInvocations(mock);
+	}
+
+	void verify_any_for_all_invocations()
+	{
+		Mock<SomeInterface> mock;
+		Fake(Method(mock,func), Method(mock,proc));
+		SomeInterface &i = mock.get();
+		i.func(5);
+		i.proc(10);
+		Verify(Method(mock, func)).Any();
+		Verify(Method(mock, proc)).Any();
+		VerifyNoOtherInvocations(mock);
+	}
+
+	void verify_any_for_only_some_invocations()
+	{
+		Mock<SomeInterface> mock;
+		Fake(Method(mock,func), Method(mock,proc));
+		SomeInterface &i = mock.get();
+		i.func(5);
+		i.proc(10);
+		Verify(Method(mock, func)).Any();
+		ASSERT_THROW(VerifyNoOtherInvocations(mock), fakeit::VerificationException);
 	}
 
 } __BasicVerification;


### PR DESCRIPTION
A flexible test may want to ignore invocations of trivial methods, like
getters and read only functions. Such methods may be called any number
of times, including none.

Currently FakeIt has no way to discard the invocations of a sequence of
methods. Using `ClearInvocationHistory` would discard all the methods,
trivial or not.

This new verification specifier, `Any`, marks a method or sequence
of methods as verified, regardless of the number of invocations
(including none).

Example:

    Verify(Method(mock, important_method)).Exactly(3);
    Verify(Method(mock, trivial_getter)).Any();
    VerifyNoOtherInvocations(mock);

Using this modifier, a flexible test may white-list the trivial methods,
and make sure that important methods are not called.