### PR TITLE
Split ci workflows and update README badges.

### DIFF
--- a/.github/workflows/ci_linux_clang.yml
+++ b/.github/workflows/ci_linux_clang.yml
@@ -1,0 +1,35 @@
+name: CI Linux/Clang
+
+on:
+  push:
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  clang-ubuntu-20-04:
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build project
+        run: |
+          cd build
+          make -f clang_makefile all
+      - name: Run tests
+        run: |
+          cd build
+          ./fakeit_tests.exe
+  clang-ubuntu-18-04:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build project
+        run: |
+          cd build
+          make -f clang_makefile all
+      - name: Run tests
+        run: |
+          cd build
+          ./fakeit_tests.exe

--- a/.github/workflows/ci_linux_gcc.yml
+++ b/.github/workflows/ci_linux_gcc.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI Linux/GCC
 
 on:
   push:
@@ -10,7 +10,7 @@ defaults:
 
 jobs:
   coverage:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - name: Install LCOV
         run: sudo apt install -y lcov
@@ -34,8 +34,8 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: ./build/report_filtered.info
-  gcc:
-    runs-on: ubuntu-latest
+  gcc-ubuntu-20-04:
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - name: Build project
@@ -46,14 +46,14 @@ jobs:
         run: |
           cd build
           ./fakeit_tests.exe
-  clang:
-    runs-on: ubuntu-latest
+  gcc-ubuntu-18-04:
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
       - name: Build project
         run: |
           cd build
-          make -f clang_makefile all
+          make all
       - name: Run tests
         run: |
           cd build

--- a/README.md
+++ b/README.md
@@ -3,8 +3,10 @@ FakeIt
  
 [![Join the chat at https://gitter.im/eranpeer/FakeIt](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/eranpeer/FakeIt?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 
-GCC: [![Build Status GCC](https://travis-ci.org/eranpeer/FakeIt.svg?branch=master)](https://travis-ci.org/eranpeer/FakeIt)
+Linux / GCC: [![Build status Linux/GCC](https://github.com/eranpeer/FakeIt/actions/workflows/ci_linux_gcc.yml/badge.svg)](https://github.com/eranpeer/FakeIt/actions/workflows/ci_linux_gcc.yml)
 [![Coverage Status](https://coveralls.io/repos/github/eranpeer/FakeIt/badge.svg?branch=master)](https://coveralls.io/github/eranpeer/FakeIt?branch=master)
+
+Linux / Clang: [![Build status Linux/Clang](https://github.com/eranpeer/FakeIt/actions/workflows/ci_linux_clang.yml/badge.svg)](https://github.com/eranpeer/FakeIt/actions/workflows/ci_linux_clang.yml)
 
 MSC: [![Build status MSC](https://ci.appveyor.com/api/projects/status/sy2dk8se2yoxaqve)](https://ci.appveyor.com/project/eranpeer/fakeit)
 


### PR DESCRIPTION
Split CI workflows to be able to show two badges (one for clang, one for GCC) on the README.