### PR TITLE
Disarm UBSAN for VirtualOffsetSelector cast

### DIFF
--- a/include/mockutils/VTUtils.hpp
+++ b/include/mockutils/VTUtils.hpp
@@ -38,6 +38,9 @@ namespace fakeit {
 
         template<typename C>
         static typename std::enable_if<std::has_virtual_destructor<C>::value, unsigned int>::type
+#if defined(__clang__)
+__attribute__((no_sanitize("undefined")))
+#endif
         getDestructorOffset() {
             VirtualOffsetSelector offsetSelctor;
             union_cast<C *>(&offsetSelctor)->~C();


### PR DESCRIPTION
Otherswise Clang will report the following:
```
.../include/standalone/fakeit.hpp:5337:47: runtime error: member call on address 0x7ffc27172e08 which does not point to an object of type 'rtc::test::tpsclient::ITestCaseHandler'
0x7ffc27172e08: note: object is of type 'fakeit::VirtualOffsetSelector'
 00 00 00 00  38 b1 5e 00 00 00 00 00  10 c0 91 01 00 00 00 00  10 c0 91 01 00 00 00 00  f8 1d 05 01
              ^~~~~~~~~~~~~~~~~~~~~~~
              vptr for 'fakeit::VirtualOffsetSelector'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior .../include/standalone/fakeit.hpp:5337:47 in

```

A reproducer:

```c++
#include <catch2/catch.hpp>
#include <catch/fakeit.hpp>

class ITestCaseHandler
{
public:
    virtual ~ITestCaseHandler() = default;
    virtual void adaptVideoBandwidth(const std::shared_ptr<int>& foo) = 0;
};

SCENARIO("MyFixture", "[UnitTest]")
{
    fakeit::Mock<ITestCaseHandler> mockTestCaseHandler;
}
```

Compiled with `clang++-12 -fsanitize=undefined -std=c++17 -O2 -DNDEBUG`.