### PR TITLE
Catch2 3

### DIFF
--- a/config/catch/CatchFakeit.hpp
+++ b/config/catch/CatchFakeit.hpp
@@ -8,6 +8,8 @@
 #elif __has_include("catch2/catch_all.hpp")
 #   include <catch2/catch_assertion_result.hpp>
 #   include <catch2/catch_test_macros.hpp>
+#elif __has_include("catch_amalgamated.hpp")
+#   include <catch_amalgamated.hpp>
 #else
 #   include <catch.hpp>
 #endif

--- a/config/catch/CatchFakeit.hpp
+++ b/config/catch/CatchFakeit.hpp
@@ -5,6 +5,9 @@
 #include "mockutils/to_string.hpp"
 #if __has_include("catch2/catch.hpp")
 #   include <catch2/catch.hpp>
+#elif __has_include("catch2/catch_all.hpp")
+#   include <catch2/catch_assertion_result.hpp>
+#   include <catch2/catch_test_macros.hpp>
 #else
 #   include <catch.hpp>
 #endif

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2021-05-12 13:47:04.979584
+ *  Generated: 2022-02-25 00:22:22.032093
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -1133,6 +1133,9 @@ namespace fakeit {
 }
 #if __has_include("catch2/catch.hpp")
 #   include <catch2/catch.hpp>
+#elif __has_include("catch2/catch_all.hpp")
+#   include <catch2/catch_assertion_result.hpp>
+#   include <catch2/catch_test_macros.hpp>
 #else
 #   include <catch.hpp>
 #endif

--- a/single_header/catch/fakeit.hpp
+++ b/single_header/catch/fakeit.hpp
@@ -2,7 +2,7 @@
 /*
  *  FakeIt - A Simplified C++ Mocking Framework
  *  Copyright (c) Eran Pe'er 2013
- *  Generated: 2022-02-25 00:22:22.032093
+ *  Generated: 2022-02-25 00:37:04.377858
  *  Distributed under the MIT License. Please refer to the LICENSE file at:
  *  https://github.com/eranpeer/FakeIt
  */
@@ -1136,6 +1136,8 @@ namespace fakeit {
 #elif __has_include("catch2/catch_all.hpp")
 #   include <catch2/catch_assertion_result.hpp>
 #   include <catch2/catch_test_macros.hpp>
+#elif __has_include("catch_amalgamated.hpp")
+#   include <catch_amalgamated.hpp>
 #else
 #   include <catch.hpp>
 #endif


### PR DESCRIPTION
This (rather trivial) commit adds support for the upcomin Catch2 v3.
From fakeit POV it's just other header file names, so nothing really exciting.

Catch2 v3 comes in either the recommended library version as well as in a single-header/single-source file amalamated version - that's why I'm checking for both.

This would fix #257.