### PR TITLE
Fix ReturnAndSet() compile error when using incompatible argument types

### DIFF
--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -436,6 +436,7 @@ namespace fakeit {
                     ArgLocator<arg_index, check_index - 1>::AssignArg(std::forward<current_arg>(p), arg_vals);
             }
 
+#if __cplusplus < 201703L
         private:
             template<typename T, typename U>
             static
@@ -452,6 +453,7 @@ namespace fakeit {
             {
                 throw std::logic_error("ReturnAndSet(): Invalid value type");
             }
+#endif
 
         };
 

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -425,11 +425,34 @@ namespace fakeit {
         struct ArgLocator {
             template<typename current_arg, typename ...T, int ...N>
             static void AssignArg(current_arg &&p, std::tuple<ArgValue<T, N>...> arg_vals) {
-                if (std::get<check_index>(arg_vals).pos == arg_index)
+#if __cplusplus >= 201703L
+                if constexpr (std::get<check_index>(arg_vals).pos == arg_index)
                     GetArg(std::forward<current_arg>(p)) = std::get<check_index>(arg_vals).value;
+#else
+                if (std::get<check_index>(arg_vals).pos == arg_index)
+                    Set(std::forward<current_arg>(p), std::get<check_index>(arg_vals).value);
+#endif
                 else if (check_index > 0)
                     ArgLocator<arg_index, check_index - 1>::AssignArg(std::forward<current_arg>(p), arg_vals);
             }
+
+        private:
+            template<typename T, typename U>
+            static
+            typename std::enable_if<std::is_convertible<U, decltype(GetArg(std::declval<T>()))>::value, void>::type
+            Set(T &&p, U &&v)
+            {
+                GetArg(std::forward<T>(p)) = v;
+            }
+
+            template<typename T, typename U>
+            static
+            typename std::enable_if<!std::is_convertible<U, decltype(GetArg(std::declval<T>()))>::value, void>::type
+            Set(T &&, U &&)
+            {
+                throw std::logic_error("ReturnAndSet(): Invalid value type");
+            }
+
         };
 
         template<int arg_index>

--- a/tests/stubbing_tests.cpp
+++ b/tests/stubbing_tests.cpp
@@ -26,6 +26,7 @@ struct BasicStubbing : tpunit::TestFixture {
                     TEST(BasicStubbing::stub_a_function_to_return_a_specified_value_always),
                     TEST(BasicStubbing::stub_a_function_to_set_specified_values_once),
                     TEST(BasicStubbing::stub_a_function_to_set_specified_values_once_form2),
+                    TEST(BasicStubbing::stub_a_function_to_set_specified_value_with_incompatible_params),
                     TEST(BasicStubbing::stub_a_function_to_set_specified_values_always),
                     TEST(BasicStubbing::stub_a_function_to_set_specified_values_always_form2),
                     TEST(BasicStubbing::stub_a_method_to_throw_a_specified_exception_once),//
@@ -167,8 +168,6 @@ struct BasicStubbing : tpunit::TestFixture {
         Mock<SomeInterface> mock;
         When(Method(mock, funcRefArgs)).ReturnAndSet(1, _2 <= 3, _1 <= 2);
         When(Method(mock, procRefArgs)).ReturnAndSet(_1 <= 4, _2 <= 5).ReturnAndSet( _2 <= 6, _1 <= 7).ReturnAndSet(_2 <= 8);
-        std::vector<std::string> v{"str"};
-        When(Method(mock, procIncompatArgs)).ReturnAndSet(_2 <= v);
 
         SomeInterface &i = mock.get();
 
@@ -196,11 +195,28 @@ struct BasicStubbing : tpunit::TestFixture {
             FAIL();
         } catch (fakeit::UnexpectedMethodCallException &) {
         }
+    }
+
+    void stub_a_function_to_set_specified_value_with_incompatible_params() {
+        Mock<SomeInterface> mock;
+        std::vector<std::string> v{"str"};
+        When(Method(mock, procIncompatArgs)).ReturnAndSet(_2 <= v);
+
+        SomeInterface &i = mock.get();
 
         std::string s;
         std::vector<std::string> chk_v;
         i.procIncompatArgs(s, chk_v);
         ASSERT_EQUAL(chk_v, v);
+
+#if __cplusplus < 201703L
+        When(Method(mock, procIncompatArgs)).ReturnAndSet(_1 <= v);
+        try {
+            i.procIncompatArgs(s, chk_v);
+            FAIL();
+        } catch (std::logic_error&) {
+        }
+#endif
     }
 
     void stub_a_function_to_set_specified_values_always() {

--- a/tests/stubbing_tests.cpp
+++ b/tests/stubbing_tests.cpp
@@ -63,6 +63,7 @@ struct BasicStubbing : tpunit::TestFixture {
 
         virtual void proc(int) = 0;
         virtual void procRefArgs(int*, int&) = 0;
+        virtual void procIncompatArgs(std::string&, std::vector<std::string>&) = 0;
     };
 
     void calling_an_unstubbed_method_should_raise_UnmockedMethodCallException() {
@@ -166,6 +167,8 @@ struct BasicStubbing : tpunit::TestFixture {
         Mock<SomeInterface> mock;
         When(Method(mock, funcRefArgs)).ReturnAndSet(1, _2 <= 3, _1 <= 2);
         When(Method(mock, procRefArgs)).ReturnAndSet(_1 <= 4, _2 <= 5).ReturnAndSet( _2 <= 6, _1 <= 7).ReturnAndSet(_2 <= 8);
+        std::vector<std::string> v{"str"};
+        When(Method(mock, procIncompatArgs)).ReturnAndSet(_2 <= v);
 
         SomeInterface &i = mock.get();
 
@@ -193,6 +196,11 @@ struct BasicStubbing : tpunit::TestFixture {
             FAIL();
         } catch (fakeit::UnexpectedMethodCallException &) {
         }
+
+        std::string s;
+        std::vector<std::string> chk_v;
+        i.procIncompatArgs(s, chk_v);
+        ASSERT_EQUAL(chk_v, v);
     }
 
     void stub_a_function_to_set_specified_values_always() {


### PR DESCRIPTION
Fixes #265

It present a sub-optimal solution for C++ < 17, since it catches type incompatibility problems at runtime rather than during compile time. But at least, it works. 

It is probably possible to make it work at compile time, specially for C++14; but I'm not sure I'll go for it.