### PR TITLE
Rewrote matcher code.

### DIFF
--- a/include/fakeit/MethodMockingContext.hpp
+++ b/include/fakeit/MethodMockingContext.hpp
@@ -222,13 +222,13 @@ namespace fakeit {
             _impl->setMethodDetails(mockName, methodName);
         }
 
-        void setMatchingCriteria(std::function<bool(arglist &...)> predicate) {
+        void setMatchingCriteria(const std::function<bool(arglist &...)>& predicate) {
             typename ActualInvocation<arglist...>::Matcher *matcher{
                     new UserDefinedInvocationMatcher<arglist...>(predicate)};
             _impl->setInvocationMatcher(matcher);
         }
 
-        void setMatchingCriteria(const std::vector<Destructible *> &matchers) {
+        void setMatchingCriteria(std::vector<Destructible *> &matchers) {
             typename ActualInvocation<arglist...>::Matcher *matcher{
                     new ArgumentsMatcherInvocationMatcher<arglist...>(matchers)};
             _impl->setInvocationMatcher(matcher);
@@ -245,13 +245,14 @@ namespace fakeit {
             _impl->setMethodBodyByAssignment(method);
         }
 
-        template<class ...matcherCreators, class = typename std::enable_if<
-                sizeof...(matcherCreators) == sizeof...(arglist)>::type>
-        void setMatchingCriteria(const matcherCreators &... matcherCreator) {
+        template<class ...matcherCreators>
+        typename std::enable_if< //
+                sizeof...(matcherCreators) == sizeof...(arglist), void> //
+        ::type setMatchingCriteria(matcherCreators &&... matcherCreator) {
             std::vector<Destructible *> matchers;
 
             MatchersCollector<0, arglist...> c(matchers);
-            c.CollectMatchers(matcherCreator...);
+            c.CollectMatchers(std::forward<matcherCreators>(matcherCreator)...);
 
             MethodMockingContext<R, arglist...>::setMatchingCriteria(matchers);
         }
@@ -287,18 +288,13 @@ namespace fakeit {
             return *this;
         }
 
-        MockingContext<R, arglist...> &Using(const arglist &... args) {
-            MethodMockingContext<R, arglist...>::setMatchingCriteria(args...);
-            return *this;
-        }
-
         template<class ...arg_matcher>
-        MockingContext<R, arglist...> &Using(const arg_matcher &... arg_matchers) {
-            MethodMockingContext<R, arglist...>::setMatchingCriteria(arg_matchers...);
+        MockingContext<R, arglist...> &Using(arg_matcher &&... arg_matchers) {
+            MethodMockingContext<R, arglist...>::setMatchingCriteria(std::forward<arg_matcher>(arg_matchers)...);
             return *this;
         }
 
-        MockingContext<R, arglist...> &Matching(std::function<bool(arglist &...)> matcher) {
+        MockingContext<R, arglist...> &Matching(const std::function<bool(arglist &...)>& matcher) {
             MethodMockingContext<R, arglist...>::setMatchingCriteria(matcher);
             return *this;
         }
@@ -308,7 +304,7 @@ namespace fakeit {
             return *this;
         }
 
-        MockingContext<R, arglist...> &operator()(std::function<bool(arglist &...)> matcher) {
+        MockingContext<R, arglist...> &operator()(const std::function<bool(arglist &...)>& matcher) {
             MethodMockingContext<R, arglist...>::setMatchingCriteria(matcher);
             return *this;
         }
@@ -352,18 +348,13 @@ namespace fakeit {
             return *this;
         }
 
-        MockingContext<void, arglist...> &Using(const arglist &... args) {
-            MethodMockingContext<void, arglist...>::setMatchingCriteria(args...);
-            return *this;
-        }
-
         template<class ...arg_matcher>
-        MockingContext<void, arglist...> &Using(const arg_matcher &... arg_matchers) {
-            MethodMockingContext<void, arglist...>::setMatchingCriteria(arg_matchers...);
+        MockingContext<void, arglist...> &Using(arg_matcher &&... arg_matchers) {
+            MethodMockingContext<void, arglist...>::setMatchingCriteria(std::forward<arg_matcher>(arg_matchers)...);
             return *this;
         }
 
-        MockingContext<void, arglist...> &Matching(std::function<bool(arglist &...)> matcher) {
+        MockingContext<void, arglist...> &Matching(const std::function<bool(arglist &...)>& matcher) {
             MethodMockingContext<void, arglist...>::setMatchingCriteria(matcher);
             return *this;
         }
@@ -373,7 +364,7 @@ namespace fakeit {
             return *this;
         }
 
-        MockingContext<void, arglist...> &operator()(std::function<bool(arglist &...)> matcher) {
+        MockingContext<void, arglist...> &operator()(const std::function<bool(arglist &...)>& matcher) {
             MethodMockingContext<void, arglist...>::setMatchingCriteria(matcher);
             return *this;
         }

--- a/include/fakeit/argument_matchers.hpp
+++ b/include/fakeit/argument_matchers.hpp
@@ -10,6 +10,8 @@
 
 #include <cstring>
 
+#include "mockutils/type_utils.hpp"
+
 namespace fakeit {
 
     struct IMatcher : Destructible {
@@ -17,479 +19,532 @@ namespace fakeit {
         virtual std::string format() const = 0;
     };
 
-    template<typename T>
+    template<typename ActualT>
     struct TypedMatcher : IMatcher {
-        virtual bool matches(const T &actual) const = 0;
+        virtual bool matches(const ActualT &actual) const = 0;
     };
 
-    template<typename T>
-    struct TypedMatcherCreator {
+    template<typename ExpectedTRef>
+    struct ComparisonMatcherCreatorBase {
+        using ExpectedT = typename naked_type<ExpectedTRef>::type;
 
-        virtual ~TypedMatcherCreator() = default;
+        ExpectedTRef _expectedRef;
 
-        virtual TypedMatcher<T> *createMatcher() const = 0;
-    };
-
-    template<typename T>
-    struct ComparisonMatcherCreator : public TypedMatcherCreator<T> {
-
-        virtual ~ComparisonMatcherCreator() = default;
-
-        ComparisonMatcherCreator(const T &arg)
-                : _expected(arg) {
+        template <typename T>
+        ComparisonMatcherCreatorBase(T &&expectedRef)
+                : _expectedRef(std::forward<T>(expectedRef)) {
         }
 
-        struct Matcher : public TypedMatcher<T> {
-            Matcher(const T &expected)
-                    : _expected(expected) {
-            }
+        template <typename ActualT, typename = ExpectedT, typename = void>
+        struct MatcherBase : public TypedMatcher<ActualT> {
+            const ExpectedT _expected;
 
-            const T _expected;
+            MatcherBase(ExpectedTRef expected)
+                    : _expected{std::forward<ExpectedTRef>(expected)} {
+            }
         };
 
-        const T &_expected;
+        template <typename ActualT, typename U>
+        struct MatcherBase<ActualT, U, typename std::enable_if<std::is_same<U, ExpectedT>::value && std::is_array<U>::value>::type> : public TypedMatcher<ActualT> {
+            ExpectedT _expected;
+
+            MatcherBase(ExpectedTRef expected) {
+                std::memcpy(_expected, expected, sizeof(_expected));
+            }
+        };
     };
 
     namespace internal {
-        template<typename T>
-        struct TypedAnyMatcher : public TypedMatcherCreator<T> {
+        struct AnyMatcherCreator{
+            template <typename ActualT>
+            struct IsTypeCompatible : std::true_type {};
 
-            virtual ~TypedAnyMatcher() = default;
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public TypedMatcher<ActualT> {
+                    bool matches(const ActualT &) const override {
+                        return true;
+                    }
 
-            TypedAnyMatcher() {
-            }
+                    std::string format() const override {
+                        return "Any";
+                    }
+                };
 
-            struct Matcher : public TypedMatcher<T> {
-                virtual bool matches(const T &) const override {
-                    return true;
-                }
-
-                virtual std::string format() const override {
-                    return "Any";
-                }
-            };
-
-            virtual TypedMatcher<T> *createMatcher() const override {
                 return new Matcher();
             }
-
         };
 
-        template<typename T>
-        struct EqMatcherCreator : public ComparisonMatcherCreator<T> {
+        template<typename ExpectedTRef>
+        struct EqMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~EqMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            EqMatcherCreator(const T &expected)
-                    : ComparisonMatcherCreator<T>(expected) {
-            }
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::declval<ActualT>() == std::declval<ExpectedT>())>> : std::true_type {};
 
-            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
-                Matcher(const T &expected)
-                        : ComparisonMatcherCreator<T>::Matcher(expected) {
-                }
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
 
-                virtual std::string format() const override {
-                    return TypeFormatter<T>::format(this->_expected);
-                }
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
 
-                virtual bool matches(const T &actual) const override {
-                    return actual == this->_expected;
-                }
-            };
+                    virtual std::string format() const override {
+                        return TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
 
-            virtual TypedMatcher<T> *createMatcher() const {
-                return new Matcher(this->_expected);
-            }
+                    virtual bool matches(const ActualT &actual) const override {
+                        return actual == this->_expected;
+                    }
+                };
 
-        };
-
-        template<typename T>
-        struct GtMatcherCreator : public ComparisonMatcherCreator<T> {
-
-            virtual ~GtMatcherCreator() = default;
-
-            GtMatcherCreator(const T &expected)
-                    : ComparisonMatcherCreator<T>(expected) {
-            }
-
-            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
-                Matcher(const T &expected)
-                        : ComparisonMatcherCreator<T>::Matcher(expected) {
-                }
-
-                virtual bool matches(const T &actual) const override {
-                    return actual > this->_expected;
-                }
-
-                virtual std::string format() const override {
-                    return std::string(">") + TypeFormatter<T>::format(this->_expected);
-                }
-            };
-
-            virtual TypedMatcher<T> *createMatcher() const override {
-                return new Matcher(this->_expected);
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
         };
 
-        template<typename T>
-        struct GeMatcherCreator : public ComparisonMatcherCreator<T> {
+        template<typename ExpectedTRef>
+        struct GtMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~GeMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            GeMatcherCreator(const T &expected)
-                    : ComparisonMatcherCreator<T>(expected) {
-            }
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::declval<ActualT>() > std::declval<ExpectedT>())>> : std::true_type {};
 
-            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
-                Matcher(const T &expected)
-                        : ComparisonMatcherCreator<T>::Matcher(expected) {
-                }
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
 
-                virtual bool matches(const T &actual) const override {
-                    return actual >= this->_expected;
-                }
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
 
-                virtual std::string format() const override {
-                    return std::string(">=") + TypeFormatter<T>::format(this->_expected);
-                }
-            };
+                    virtual std::string format() const override {
+                        return std::string(">") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
 
-            virtual TypedMatcher<T> *createMatcher() const override {
-                return new Matcher(this->_expected);
+                    virtual bool matches(const ActualT &actual) const override {
+                        return actual > this->_expected;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
         };
 
-        template<typename T>
-        struct LtMatcherCreator : public ComparisonMatcherCreator<T> {
+        template<typename ExpectedTRef>
+        struct GeMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~LtMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            LtMatcherCreator(const T &expected)
-                    : ComparisonMatcherCreator<T>(expected) {
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::declval<ActualT>() >= std::declval<ExpectedT>())>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string(">=") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return actual >= this->_expected;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
-
-            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
-                Matcher(const T &expected)
-                        : ComparisonMatcherCreator<T>::Matcher(expected) {
-                }
-
-                virtual bool matches(const T &actual) const override {
-                    return actual < this->_expected;
-                }
-
-                virtual std::string format() const override {
-                    return std::string("<") + TypeFormatter<T>::format(this->_expected);
-                }
-            };
-
-            virtual TypedMatcher<T> *createMatcher() const override {
-                return new Matcher(this->_expected);
-            }
-
         };
 
-        template<typename T>
-        struct LeMatcherCreator : public ComparisonMatcherCreator<T> {
+        template<typename ExpectedTRef>
+        struct LtMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~LeMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            LeMatcherCreator(const T &expected)
-                    : ComparisonMatcherCreator<T>(expected) {
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::declval<ActualT>() < std::declval<ExpectedT>())>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string("<") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return actual < this->_expected;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
-
-            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
-                Matcher(const T &expected)
-                        : ComparisonMatcherCreator<T>::Matcher(expected) {
-                }
-
-                virtual bool matches(const T &actual) const override {
-                    return actual <= this->_expected;
-                }
-
-                virtual std::string format() const override {
-                    return std::string("<=") + TypeFormatter<T>::format(this->_expected);
-                }
-            };
-
-            virtual TypedMatcher<T> *createMatcher() const override {
-                return new Matcher(this->_expected);
-            }
-
         };
 
-        template<typename T>
-        struct NeMatcherCreator : public ComparisonMatcherCreator<T> {
+        template<typename ExpectedTRef>
+        struct LeMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~NeMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            NeMatcherCreator(const T &expected)
-                    : ComparisonMatcherCreator<T>(expected) {
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::declval<ActualT>() <= std::declval<ExpectedT>())>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string("<=") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return actual <= this->_expected;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
-
-            struct Matcher : public ComparisonMatcherCreator<T>::Matcher {
-                Matcher(const T &expected)
-                        : ComparisonMatcherCreator<T>::Matcher(expected) {
-                }
-
-                virtual bool matches(const T &actual) const override {
-                    return actual != this->_expected;
-                }
-
-                virtual std::string format() const override {
-                    return std::string("!=") + TypeFormatter<T>::format(this->_expected);
-                }
-
-            };
-
-            virtual TypedMatcher<T> *createMatcher() const override {
-                return new Matcher(this->_expected);
-            }
-
         };
 
-        struct StrEqMatcherCreator : public ComparisonMatcherCreator<const char*> {
+        template<typename ExpectedTRef>
+        struct NeMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~StrEqMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            StrEqMatcherCreator(const char* const &expected)
-                    : ComparisonMatcherCreator<const char*>(expected) {
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(std::declval<ActualT>() != std::declval<ExpectedT>())>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string("!=") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return actual != this->_expected;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
-
-            struct Matcher : public ComparisonMatcherCreator<const char*>::Matcher {
-                Matcher(const char* const &expected)
-                        : ComparisonMatcherCreator<const char*>::Matcher(expected) {
-                }
-
-                virtual std::string format() const override {
-                    return TypeFormatter<const char*>::format(this->_expected);
-                }
-
-                virtual bool matches(const char* const &actual) const override {
-                    return std::strcmp(actual, this->_expected) == 0;
-                }
-            };
-
-            virtual TypedMatcher<const char*> *createMatcher() const {
-                return new Matcher(this->_expected);
-            }
-
         };
 
-        struct StrGtMatcherCreator : public ComparisonMatcherCreator<const char*> {
+        template <typename ExpectedTRef>
+        struct StrEqMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~StrGtMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            StrGtMatcherCreator(const char* const &expected)
-                    : ComparisonMatcherCreator<const char*>(expected) {
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(strcmp(std::declval<ActualT>(), std::declval<const char*>()))>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::strcmp(actual, this->_expected.c_str()) == 0;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
-
-            struct Matcher : public ComparisonMatcherCreator<const char*>::Matcher {
-                Matcher(const char* const &expected)
-                        : ComparisonMatcherCreator<const char*>::Matcher(expected) {
-                }
-
-                virtual std::string format() const override {
-                    return std::string(">") + TypeFormatter<const char*>::format(this->_expected);
-                }
-
-                virtual bool matches(const char* const &actual) const override {
-                    return std::strcmp(actual, this->_expected) > 0;
-                }
-            };
-
-            virtual TypedMatcher<const char*> *createMatcher() const {
-                return new Matcher(this->_expected);
-            }
-
         };
 
-        struct StrGeMatcherCreator : public ComparisonMatcherCreator<const char*> {
+        template <typename ExpectedTRef>
+        struct StrGtMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~StrGeMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            StrGeMatcherCreator(const char* const &expected)
-                    : ComparisonMatcherCreator<const char*>(expected) {
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(strcmp(std::declval<ActualT>(), std::declval<const char*>()))>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string(">") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::strcmp(actual, this->_expected.c_str()) > 0;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
-
-            struct Matcher : public ComparisonMatcherCreator<const char*>::Matcher {
-                Matcher(const char* const &expected)
-                        : ComparisonMatcherCreator<const char*>::Matcher(expected) {
-                }
-
-                virtual std::string format() const override {
-                    return std::string(">=") + TypeFormatter<const char*>::format(this->_expected);
-                }
-
-                virtual bool matches(const char* const &actual) const override {
-                    return std::strcmp(actual, this->_expected) >= 0;
-                }
-            };
-
-            virtual TypedMatcher<const char*> *createMatcher() const {
-                return new Matcher(this->_expected);
-            }
-
         };
 
-        struct StrLtMatcherCreator : public ComparisonMatcherCreator<const char*> {
+        template <typename ExpectedTRef>
+        struct StrGeMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~StrLtMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            StrLtMatcherCreator(const char* const &expected)
-                    : ComparisonMatcherCreator<const char*>(expected) {
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(strcmp(std::declval<ActualT>(), std::declval<const char*>()))>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string(">=") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::strcmp(actual, this->_expected.c_str()) >= 0;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
-
-            struct Matcher : public ComparisonMatcherCreator<const char*>::Matcher {
-                Matcher(const char* const &expected)
-                        : ComparisonMatcherCreator<const char*>::Matcher(expected) {
-                }
-
-                virtual std::string format() const override {
-                    return std::string("<") + TypeFormatter<const char*>::format(this->_expected);
-                }
-
-                virtual bool matches(const char* const &actual) const override {
-                    return std::strcmp(actual, this->_expected) < 0;
-                }
-            };
-
-            virtual TypedMatcher<const char*> *createMatcher() const {
-                return new Matcher(this->_expected);
-            }
-
         };
 
-        struct StrLeMatcherCreator : public ComparisonMatcherCreator<const char*> {
+        template <typename ExpectedTRef>
+        struct StrLtMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~StrLeMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            StrLeMatcherCreator(const char* const &expected)
-                    : ComparisonMatcherCreator<const char*>(expected) {
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(strcmp(std::declval<ActualT>(), std::declval<const char*>()))>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string("<") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::strcmp(actual, this->_expected.c_str()) < 0;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
-
-            struct Matcher : public ComparisonMatcherCreator<const char*>::Matcher {
-                Matcher(const char* const &expected)
-                        : ComparisonMatcherCreator<const char*>::Matcher(expected) {
-                }
-
-                virtual std::string format() const override {
-                    return std::string("<=") + TypeFormatter<const char*>::format(this->_expected);
-                }
-
-                virtual bool matches(const char* const &actual) const override {
-                    return std::strcmp(actual, this->_expected) <= 0;
-                }
-            };
-
-            virtual TypedMatcher<const char*> *createMatcher() const {
-                return new Matcher(this->_expected);
-            }
-
         };
 
-        struct StrNeMatcherCreator : public ComparisonMatcherCreator<const char*> {
+        template <typename ExpectedTRef>
+        struct StrLeMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-            virtual ~StrNeMatcherCreator() = default;
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-            StrNeMatcherCreator(const char* const &expected)
-                    : ComparisonMatcherCreator<const char*>(expected) {
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(strcmp(std::declval<ActualT>(), std::declval<const char*>()))>> : std::true_type {};
+
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string("<=") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::strcmp(actual, this->_expected.c_str()) <= 0;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
+        };
 
-            struct Matcher : public ComparisonMatcherCreator<const char*>::Matcher {
-                Matcher(const char* const &expected)
-                        : ComparisonMatcherCreator<const char*>::Matcher(expected) {
-                }
+        template <typename ExpectedTRef>
+        struct StrNeMatcherCreator : public ComparisonMatcherCreatorBase<ExpectedTRef> {
+            using ExpectedT = typename ComparisonMatcherCreatorBase<ExpectedTRef>::ExpectedT;
 
-                virtual std::string format() const override {
-                    return std::string("!=") + TypeFormatter<const char*>::format(this->_expected);
-                }
+            template <typename ActualT, typename = void>
+            struct IsTypeCompatible : std::false_type {};
 
-                virtual bool matches(const char* const &actual) const override {
-                    return std::strcmp(actual, this->_expected) != 0;
-                }
-            };
+            template <typename ActualT>
+            struct IsTypeCompatible<ActualT, fk_void_t<decltype(strcmp(std::declval<ActualT>(), std::declval<const char*>()))>> : std::true_type {};
 
-            virtual TypedMatcher<const char*> *createMatcher() const {
-                return new Matcher(this->_expected);
+            using ComparisonMatcherCreatorBase<ExpectedTRef>::ComparisonMatcherCreatorBase;
+
+            template<typename ActualT>
+            TypedMatcher<ActualT> *createMatcher() const {
+                struct Matcher : public ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT> {
+                    using ComparisonMatcherCreatorBase<ExpectedTRef>::template MatcherBase<ActualT>::MatcherBase;
+
+                    virtual std::string format() const override {
+                        return std::string("!=") + TypeFormatter<ExpectedT>::format(this->_expected);
+                    }
+
+                    virtual bool matches(const ActualT &actual) const override {
+                        return std::strcmp(actual, this->_expected.c_str()) != 0;
+                    }
+                };
+
+                return new Matcher(std::forward<ExpectedTRef>(this->_expectedRef));
             }
-
         };
     }
 
     struct AnyMatcher {
     } static _;
 
-    template<typename T>
-    internal::TypedAnyMatcher<T> Any() {
-        internal::TypedAnyMatcher<T> rv;
-        return rv;
+    template <typename T>
+    internal::AnyMatcherCreator Any() {
+        static_assert(sizeof(T) >= 0, "To maintain backward compatibility, this function takes an useless template argument.");
+        internal::AnyMatcherCreator mc;
+        return mc;
+    }
+
+    inline internal::AnyMatcherCreator Any() {
+        internal::AnyMatcherCreator mc;
+        return mc;
     }
 
     template<typename T>
-    internal::EqMatcherCreator<T> Eq(const T &arg) {
-        internal::EqMatcherCreator<T> rv(arg);
-        return rv;
+    internal::EqMatcherCreator<T&&> Eq(T &&arg) {
+        internal::EqMatcherCreator<T&&> mc(std::forward<T>(arg));
+        return mc;
     }
 
     template<typename T>
-    internal::GtMatcherCreator<T> Gt(const T &arg) {
-        internal::GtMatcherCreator<T> rv(arg);
-        return rv;
+    internal::GtMatcherCreator<T&&> Gt(T &&arg) {
+        internal::GtMatcherCreator<T&&> mc(std::forward<T>(arg));
+        return mc;
     }
 
     template<typename T>
-    internal::GeMatcherCreator<T> Ge(const T &arg) {
-        internal::GeMatcherCreator<T> rv(arg);
-        return rv;
+    internal::GeMatcherCreator<T&&> Ge(T &&arg) {
+        internal::GeMatcherCreator<T&&> mc(std::forward<T>(arg));
+        return mc;
     }
 
     template<typename T>
-    internal::LtMatcherCreator<T> Lt(const T &arg) {
-        internal::LtMatcherCreator<T> rv(arg);
-        return rv;
+    internal::LtMatcherCreator<T&&> Lt(T &&arg) {
+        internal::LtMatcherCreator<T&&> mc(std::forward<T>(arg));
+        return mc;
     }
 
     template<typename T>
-    internal::LeMatcherCreator<T> Le(const T &arg) {
-        internal::LeMatcherCreator<T> rv(arg);
-        return rv;
+    internal::LeMatcherCreator<T&&> Le(T &&arg) {
+        internal::LeMatcherCreator<T&&> mc(std::forward<T>(arg));
+        return mc;
     }
 
     template<typename T>
-    internal::NeMatcherCreator<T> Ne(const T &arg) {
-        internal::NeMatcherCreator<T> rv(arg);
-        return rv;
+    internal::NeMatcherCreator<T&&> Ne(T &&arg) {
+        internal::NeMatcherCreator<T&&> mc(std::forward<T>(arg));
+        return mc;
     }
 
-    inline internal::StrEqMatcherCreator StrEq(const char* const &arg) {
-        internal::StrEqMatcherCreator rv(arg);
-        return rv;
+    inline internal::StrEqMatcherCreator<std::string&&> StrEq(std::string&& arg) {
+        internal::StrEqMatcherCreator<std::string&&> mc(std::move(arg));
+        return mc;
     }
 
-    inline internal::StrGtMatcherCreator StrGt(const char* const &arg) {
-        internal::StrGtMatcherCreator rv(arg);
-        return rv;
+    inline internal::StrEqMatcherCreator<const std::string&> StrEq(const std::string& arg) {
+        internal::StrEqMatcherCreator<const std::string&> mc(arg);
+        return mc;
     }
 
-    inline internal::StrGeMatcherCreator StrGe(const char* const &arg) {
-        internal::StrGeMatcherCreator rv(arg);
-        return rv;
+    inline internal::StrGtMatcherCreator<std::string&&> StrGt(std::string&& arg) {
+        internal::StrGtMatcherCreator<std::string&&> mc(std::move(arg));
+        return mc;
     }
 
-    inline internal::StrLtMatcherCreator StrLt(const char* const &arg) {
-        internal::StrLtMatcherCreator rv(arg);
-        return rv;
+    inline internal::StrGtMatcherCreator<const std::string&> StrGt(const std::string& arg) {
+        internal::StrGtMatcherCreator<const std::string&> mc(arg);
+        return mc;
     }
 
-    inline internal::StrLeMatcherCreator StrLe(const char* const &arg) {
-        internal::StrLeMatcherCreator rv(arg);
-        return rv;
+    inline internal::StrGeMatcherCreator<std::string&&> StrGe(std::string&& arg) {
+        internal::StrGeMatcherCreator<std::string&&> mc(std::move(arg));
+        return mc;
     }
 
-    inline internal::StrNeMatcherCreator StrNe(const char* const &arg) {
-        internal::StrNeMatcherCreator rv(arg);
-        return rv;
+    inline internal::StrGeMatcherCreator<const std::string&> StrGe(const std::string& arg) {
+        internal::StrGeMatcherCreator<const std::string&> mc(arg);
+        return mc;
+    }
+
+    inline internal::StrLtMatcherCreator<std::string&&> StrLt(std::string&& arg) {
+        internal::StrLtMatcherCreator<std::string&&> mc(std::move(arg));
+        return mc;
+    }
+
+    inline internal::StrLtMatcherCreator<const std::string&> StrLt(const std::string& arg) {
+        internal::StrLtMatcherCreator<const std::string&> mc(arg);
+        return mc;
+    }
+
+    inline internal::StrLeMatcherCreator<std::string&&> StrLe(std::string&& arg) {
+        internal::StrLeMatcherCreator<std::string&&> mc(std::move(arg));
+        return mc;
+    }
+
+    inline internal::StrLeMatcherCreator<const std::string&> StrLe(const std::string& arg) {
+        internal::StrLeMatcherCreator<const std::string&> mc(arg);
+        return mc;
+    }
+
+    inline internal::StrNeMatcherCreator<std::string&&> StrNe(std::string&& arg) {
+        internal::StrNeMatcherCreator<std::string&&> mc(std::move(arg));
+        return mc;
+    }
+
+    inline internal::StrNeMatcherCreator<const std::string&> StrNe(const std::string& arg) {
+        internal::StrNeMatcherCreator<const std::string&> mc(arg);
+        return mc;
     }
 
 }

--- a/include/fakeit/invocation_matchers.hpp
+++ b/include/fakeit/invocation_matchers.hpp
@@ -120,7 +120,7 @@ namespace fakeit {
     struct UserDefinedInvocationMatcher : ActualInvocation<arglist...>::Matcher {
         virtual ~UserDefinedInvocationMatcher() = default;
 
-        UserDefinedInvocationMatcher(std::function<bool(arglist &...)> match)
+        UserDefinedInvocationMatcher(const std::function<bool(arglist &...)>& match)
                 : matcher{match} {
         }
 

--- a/include/mockutils/type_utils.hpp
+++ b/include/mockutils/type_utils.hpp
@@ -13,6 +13,9 @@
 
 namespace fakeit {
 
+    template<class...>
+    using fk_void_t = void;
+
     template<class C>
     struct naked_type {
         typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;

--- a/tests/argument_matching_tests.cpp
+++ b/tests/argument_matching_tests.cpp
@@ -12,11 +12,26 @@
 
 using namespace fakeit;
 
+namespace {
+	struct Base {
+		virtual ~Base() = default;
+		virtual int value() const { return 1; }
+	};
+
+	struct Derivated : public Base {
+		int value() const override { return 2; }
+	};
+
+	bool operator==(const Base& lhs, const Base& rhs) {
+		return lhs.value() == rhs.value();
+	}
+}
+
 struct ArgumentMatchingTests: tpunit::TestFixture {
 	ArgumentMatchingTests()
 			: tpunit::TestFixture(
 					//
-                    TEST(ArgumentMatchingTests::pass_reference_by_value),
+					TEST(ArgumentMatchingTests::mixed_matchers),
 					TEST(ArgumentMatchingTests::test_eq_matcher), TEST(ArgumentMatchingTests::test_ge_matcher),
 					TEST(ArgumentMatchingTests::test_lt_matcher), TEST(ArgumentMatchingTests::test_le_matcher),
 					TEST(ArgumentMatchingTests::test_ne_matcher), TEST(ArgumentMatchingTests::test_gt_matcher),
@@ -24,6 +39,8 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 					TEST(ArgumentMatchingTests::test_str_ge_matcher), TEST(ArgumentMatchingTests::test_str_lt_matcher),
 					TEST(ArgumentMatchingTests::test_str_le_matcher), TEST(ArgumentMatchingTests::test_str_ne_matcher),
 					TEST(ArgumentMatchingTests::test_any_matcher), TEST(ArgumentMatchingTests::test_any_matcher2),
+					TEST(ArgumentMatchingTests::test_any_matcher3),
+					TEST(ArgumentMatchingTests::pass_reference_by_value),
 					TEST(ArgumentMatchingTests::format_Any), TEST(ArgumentMatchingTests::format_Eq),
 					TEST(ArgumentMatchingTests::format_Gt), TEST(ArgumentMatchingTests::format_Ge),
 					TEST(ArgumentMatchingTests::format_Lt), TEST(ArgumentMatchingTests::format_Le),
@@ -31,7 +48,7 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 					TEST(ArgumentMatchingTests::format_StrEq), TEST(ArgumentMatchingTests::format_StrGt),
 					TEST(ArgumentMatchingTests::format_StrGe), TEST(ArgumentMatchingTests::format_StrLt),
 					TEST(ArgumentMatchingTests::format_StrLe), TEST(ArgumentMatchingTests::format_StrNe),
-                    TEST(ArgumentMatchingTests::mixed_matchers)
+					TEST(ArgumentMatchingTests::test_move_only_type), TEST(ArgumentMatchingTests::test_no_slicing)
 			) //
 	{
 	}
@@ -44,11 +61,21 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 #endif
     }
 
+	struct MoveOnlyType {
+		const int i_;
+		MoveOnlyType(int i) : i_{i} {}
+		MoveOnlyType(const MoveOnlyType&) = delete;
+		MoveOnlyType(MoveOnlyType&& o) : i_{o.i_} {};
+		bool operator==(const MoveOnlyType& o) const { return i_ == o.i_; }
+	};
+
 	struct SomeInterface {
 		virtual int func(int) = 0;
 		virtual int func2(int, std::string) = 0;
         virtual int func3(const int&) = 0;
         virtual int strfunc(const char*) = 0;
+		virtual int funcMoveOnly(MoveOnlyType) = 0;
+		virtual int funcSlicing(const Base&) = 0;
     };
 
 	void mixed_matchers() {
@@ -170,11 +197,12 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 	}
 
 	void test_str_eq_matcher() {
+		std::string second = "second";
 
 		Mock<SomeInterface> mock;
 
 		When(Method(mock, strfunc).Using(StrEq("first"))).Return(1);
-		When(Method(mock, strfunc).Using(StrEq("second"))).Return(2);
+		When(Method(mock, strfunc).Using(StrEq(second))).Return(2);
 
 		SomeInterface &i = mock.get();
 		ASSERT_EQUAL(1, i.strfunc("first"));
@@ -185,11 +213,12 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 	}
 
 	void test_str_gt_matcher() {
+		std::string bb = "bb";
 
 		Mock<SomeInterface> mock;
 
 		When(Method(mock, strfunc).Using(StrGt("aa"))).Return(1);
-		When(Method(mock, strfunc).Using(StrGt("bb"))).Return(2);
+		When(Method(mock, strfunc).Using(StrGt(bb))).Return(2);
 
 		SomeInterface &i = mock.get();
 		ASSERT_EQUAL(1, i.strfunc("ab"));
@@ -200,11 +229,12 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 	}
 
 	void test_str_ge_matcher() {
+		std::string bb = "bb";
 
 		Mock<SomeInterface> mock;
 
 		When(Method(mock, strfunc).Using(StrGe("aa"))).Return(1);
-		When(Method(mock, strfunc).Using(StrGe("bb"))).Return(2);
+		When(Method(mock, strfunc).Using(StrGe(bb))).Return(2);
 
 		SomeInterface &i = mock.get();
 		ASSERT_EQUAL(1, i.strfunc("ab"));
@@ -215,11 +245,12 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 	}
 
 	void test_str_lt_matcher() {
+		std::string bb = "bb";
 
 		Mock<SomeInterface> mock;
 
 		When(Method(mock, strfunc).Using(StrLt("cc"))).Return(1);
-		When(Method(mock, strfunc).Using(StrLt("bb"))).Return(2);
+		When(Method(mock, strfunc).Using(StrLt(bb))).Return(2);
 
 		SomeInterface &i = mock.get();
 		ASSERT_EQUAL(1, i.strfunc("cb"));
@@ -230,11 +261,12 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 	}
 
 	void test_str_le_matcher() {
+		std::string bb = "bb";
 
 		Mock<SomeInterface> mock;
 
 		When(Method(mock, strfunc).Using(StrLe("cc"))).Return(1);
-		When(Method(mock, strfunc).Using(StrLe("bb"))).Return(2);
+		When(Method(mock, strfunc).Using(StrLe(bb))).Return(2);
 
 		SomeInterface &i = mock.get();
 		ASSERT_EQUAL(1, i.strfunc("cc"));
@@ -245,11 +277,12 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 	}
 
 	void test_str_ne_matcher() {
+		std::string second = "second";
 
 		Mock<SomeInterface> mock;
 
 		When(Method(mock, strfunc).Using(StrNe("first"))).Return(1);
-		When(Method(mock, strfunc).Using(StrNe("second"))).Return(2);
+		When(Method(mock, strfunc).Using(StrNe(second))).Return(2);
 
 		SomeInterface &i = mock.get();
 		ASSERT_EQUAL(1, i.strfunc("second"));
@@ -283,6 +316,19 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 		ASSERT_EQUAL(1, i.func(1));
 
 		Verify(Method(mock, func).Using(_)).Twice();
+	}
+
+	void test_any_matcher3() {
+
+		Mock<SomeInterface> mock;
+
+		When(Method(mock, func).Using(Any())).AlwaysReturn(1);
+
+		SomeInterface &i = mock.get();
+		ASSERT_EQUAL(1, i.func(2));
+		ASSERT_EQUAL(1, i.func(1));
+
+		Verify(Method(mock, func).Using(Any())).Twice();
 	}
 
     void pass_reference_by_value() {
@@ -416,7 +462,7 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 		} catch (SequenceVerificationException& e) {
 			std::string expectedMsg{ formatLineNumner("test file", 1) };
 			expectedMsg += ": Verification error\n";
-			expectedMsg += "Expected pattern: mock.strfunc(\"first\")\n";
+			expectedMsg += "Expected pattern: mock.strfunc(first)\n";
 			expectedMsg += "Expected matches: exactly 1\n";
 			expectedMsg += "Actual matches  : 0\n";
 			expectedMsg += "Actual sequence : total of 0 actual invocations.";
@@ -432,7 +478,7 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 		} catch (SequenceVerificationException& e) {
 			std::string expectedMsg{ formatLineNumner("test file", 1) };
 			expectedMsg += ": Verification error\n";
-			expectedMsg += "Expected pattern: mock.strfunc(>\"first\")\n";
+			expectedMsg += "Expected pattern: mock.strfunc(>first)\n";
 			expectedMsg += "Expected matches: exactly 1\n";
 			expectedMsg += "Actual matches  : 0\n";
 			expectedMsg += "Actual sequence : total of 0 actual invocations.";
@@ -448,7 +494,7 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 		} catch (SequenceVerificationException& e) {
 			std::string expectedMsg{ formatLineNumner("test file", 1) };
 			expectedMsg += ": Verification error\n";
-			expectedMsg += "Expected pattern: mock.strfunc(>=\"first\")\n";
+			expectedMsg += "Expected pattern: mock.strfunc(>=first)\n";
 			expectedMsg += "Expected matches: exactly 1\n";
 			expectedMsg += "Actual matches  : 0\n";
 			expectedMsg += "Actual sequence : total of 0 actual invocations.";
@@ -464,7 +510,7 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 		} catch (SequenceVerificationException& e) {
 			std::string expectedMsg{ formatLineNumner("test file", 1) };
 			expectedMsg += ": Verification error\n";
-			expectedMsg += "Expected pattern: mock.strfunc(<\"first\")\n";
+			expectedMsg += "Expected pattern: mock.strfunc(<first)\n";
 			expectedMsg += "Expected matches: exactly 1\n";
 			expectedMsg += "Actual matches  : 0\n";
 			expectedMsg += "Actual sequence : total of 0 actual invocations.";
@@ -480,7 +526,7 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 		} catch (SequenceVerificationException& e) {
 			std::string expectedMsg{ formatLineNumner("test file", 1) };
 			expectedMsg += ": Verification error\n";
-			expectedMsg += "Expected pattern: mock.strfunc(<=\"first\")\n";
+			expectedMsg += "Expected pattern: mock.strfunc(<=first)\n";
 			expectedMsg += "Expected matches: exactly 1\n";
 			expectedMsg += "Actual matches  : 0\n";
 			expectedMsg += "Actual sequence : total of 0 actual invocations.";
@@ -496,13 +542,42 @@ struct ArgumentMatchingTests: tpunit::TestFixture {
 		} catch (SequenceVerificationException& e) {
 			std::string expectedMsg{ formatLineNumner("test file", 1) };
 			expectedMsg += ": Verification error\n";
-			expectedMsg += "Expected pattern: mock.strfunc(!=\"first\")\n";
+			expectedMsg += "Expected pattern: mock.strfunc(!=first)\n";
 			expectedMsg += "Expected matches: exactly 1\n";
 			expectedMsg += "Actual matches  : 0\n";
 			expectedMsg += "Actual sequence : total of 0 actual invocations.";
 			std::string actualMsg { to_string(e) };
 			ASSERT_EQUAL(expectedMsg, actualMsg);
 		}
+	}
+
+	void test_move_only_type() {
+		Mock<SomeInterface> mock;
+
+		When(Method(mock, funcMoveOnly).Using(MoveOnlyType{10})).Return(1);
+		When(Method(mock, funcMoveOnly).Using(Eq(MoveOnlyType{20}))).Return(2);
+
+		SomeInterface& i = mock.get();
+		ASSERT_EQUAL(1, i.funcMoveOnly(MoveOnlyType{10}));
+		ASSERT_EQUAL(2, i.funcMoveOnly(MoveOnlyType{20}));
+
+		Verify(Method(mock, funcMoveOnly).Using(MoveOnlyType{10})).Once();
+		Verify(Method(mock, funcMoveOnly).Using(Eq(MoveOnlyType{20}))).Once();
+	}
+
+	void test_no_slicing() {
+		Mock<SomeInterface> mock;
+
+		When(Method(mock, funcSlicing).Using(Base{})).Return(1);
+		When(Method(mock, funcSlicing).Using(Derivated{})).Return(2);
+
+		SomeInterface& i = mock.get();
+		ASSERT_EQUAL(1, i.funcSlicing(Base{}));
+		ASSERT_EQUAL(2, i.funcSlicing(Derivated{}));
+
+		//Not possible to verify because only references are stored in mock objects and they are dangling.
+		//Verify(Method(mock, funcSlicing).Using(Base{})).Once();
+		//Verify(Method(mock, funcSlicing).Using(Derivated{})).Once();
 	}
 } __ArgumentMatching;
 

--- a/tests/default_event_formatting_tests.cpp
+++ b/tests/default_event_formatting_tests.cpp
@@ -230,7 +230,7 @@ struct DefaultEventFormatting: tpunit::TestFixture {
 		When(Method(mock, all_types)).Return(0);
 		//SomeInterface &i = mock.get();
 		try {
-			fakeit::Verify(Method(mock, all_types).Using('a', true, 1, 1, 1, 1, 0, 0))//
+			fakeit::Verify(Method(mock, all_types).Using('a', true, 1, 1u, 1l, 1ul, 0., 0.l))//
 				.setFileInfo("test file", 1, "test method").Exactly(2);
 			FAIL();
 		}


### PR DESCRIPTION
Now expected type doesn't need to be the same (or convertible) to the actual type. And the expected value is moved if possible, instead of always copied.

Should fix #240.