### PR TITLE
Fix Spy() to copy args and add SpyWithoutVerify() for move-only types

### DIFF
--- a/include/fakeit/MethodMockingContext.hpp
+++ b/include/fakeit/MethodMockingContext.hpp
@@ -52,7 +52,8 @@ namespace fakeit {
             /**
              * Return the original method. not the mock.
              */
-            virtual typename std::function<R(arglist&...)> getOriginalMethod() = 0;
+            virtual typename std::function<R(arglist&...)> getOriginalMethodCopyArgs() = 0;
+            virtual typename std::function<R(arglist&...)> getOriginalMethodForwardArgs() = 0;
 
             virtual std::string getMethodName() = 0;
 
@@ -153,8 +154,12 @@ namespace fakeit {
                 into.push_back(&getStubbingContext().getInvolvedMock());
             }
 
-            typename std::function<R(arglist &...)> getOriginalMethod() {
-                return getStubbingContext().getOriginalMethod();
+            typename std::function<R(arglist &...)> getOriginalMethodCopyArgs() {
+                return getStubbingContext().getOriginalMethodCopyArgs();
+            }
+
+            typename std::function<R(arglist &...)> getOriginalMethodForwardArgs() {
+                return getStubbingContext().getOriginalMethodForwardArgs();
             }
 
             void setInvocationMatcher(typename ActualInvocation<arglist...>::Matcher *matcher) {
@@ -259,8 +264,12 @@ namespace fakeit {
 
     private:
 
-        typename std::function<R(arglist&...)> getOriginalMethod() override {
-            return _impl->getOriginalMethod();
+        typename std::function<R(arglist&...)> getOriginalMethodCopyArgs() override {
+            return _impl->getOriginalMethodCopyArgs();
+        }
+
+        typename std::function<R(arglist&...)> getOriginalMethodForwardArgs() override {
+            return _impl->getOriginalMethodForwardArgs();
         }
 
         std::shared_ptr<Implementation> _impl;

--- a/include/fakeit/SpyFunctor.hpp
+++ b/include/fakeit/SpyFunctor.hpp
@@ -7,21 +7,29 @@
  */
 #pragma once
 
+#include <type_traits>
+
 #include "fakeit/StubbingProgress.hpp"
 #include "fakeit/StubbingImpl.hpp"
 #include "fakeit/SpyingContext.hpp"
+#include "mockutils/type_utils.hpp"
 
 namespace fakeit {
 
     class SpyFunctor {
     private:
 
-        template<typename R, typename ... arglist>
-        void spy(const SpyingContext<R, arglist...> &root) {
+        template<typename R, typename ... arglist, typename std::enable_if<all_true<std::is_copy_constructible<arglist>::value...>::value, int>::type = 0>
+        void spy(const SpyingContext<R, arglist...> &root, int) {
             SpyingContext<R, arglist...> &rootWithoutConst = const_cast<SpyingContext<R, arglist...> &>(root);
-            auto methodFromOriginalVT = rootWithoutConst.getOriginalMethod();
+            auto methodFromOriginalVT = rootWithoutConst.getOriginalMethodCopyArgs();
             rootWithoutConst.appendAction(new ReturnDelegateValue<R, arglist...>(methodFromOriginalVT));
             rootWithoutConst.commit();
+        }
+
+        template<typename R, typename ... arglist>
+        void spy(const SpyingContext<R, arglist...> &, long) {
+            static_assert(!std::is_same<R, R>::value, "Spy() cannot accept move-only args, use SpyWithoutVerify() instead which is able to forward these args but then they won't be available for Verify().");
         }
 
         void operator()() {
@@ -31,7 +39,7 @@ namespace fakeit {
 
         template<typename H, typename ... M>
         void operator()(const H &head, const M &... tail) {
-            spy(head);
+            spy(head, 0);
             this->operator()(tail...);
         }
 

--- a/include/fakeit/SpyWithoutVerifyFunctor.hpp
+++ b/include/fakeit/SpyWithoutVerifyFunctor.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include "fakeit/StubbingProgress.hpp"
+#include "fakeit/StubbingImpl.hpp"
+#include "fakeit/SpyingContext.hpp"
+
+namespace fakeit {
+
+    class SpyWithoutVerifyFunctor {
+    private:
+
+        template<typename R, typename ... arglist>
+        void spy(const SpyingContext<R, arglist...> &root) {
+            SpyingContext<R, arglist...> &rootWithoutConst = const_cast<SpyingContext<R, arglist...> &>(root);
+            auto methodFromOriginalVT = rootWithoutConst.getOriginalMethodForwardArgs();
+            rootWithoutConst.appendAction(new ReturnDelegateValue<R, arglist...>(methodFromOriginalVT));
+            rootWithoutConst.commit();
+        }
+
+        void operator()() {
+        }
+
+    public:
+
+        template<typename H, typename ... M>
+        void operator()(const H &head, const M &... tail) {
+            spy(head);
+            this->operator()(tail...);
+        }
+
+    };
+
+}

--- a/include/fakeit/SpyingContext.hpp
+++ b/include/fakeit/SpyingContext.hpp
@@ -18,6 +18,7 @@ namespace fakeit {
     struct SpyingContext : Xaction {
         virtual void appendAction(Action<R, arglist...> *action) = 0;
 
-        virtual std::function<R(arglist&...)> getOriginalMethod() = 0;
+        virtual std::function<R(arglist&...)> getOriginalMethodCopyArgs() = 0;
+        virtual std::function<R(arglist&...)> getOriginalMethodForwardArgs() = 0;
     };
 }

--- a/include/fakeit/api_functors.hpp
+++ b/include/fakeit/api_functors.hpp
@@ -4,6 +4,7 @@
 #include "fakeit/VerifyFunctor.hpp"
 #include "fakeit/VerifyNoOtherInvocationsFunctor.hpp"
 #include "fakeit/SpyFunctor.hpp"
+#include "fakeit/SpyWithoutVerifyFunctor.hpp"
 #include "fakeit/FakeFunctor.hpp"
 #include "fakeit/WhenFunctor.hpp"
 #include "fakeit/UnverifiedFunctor.hpp"
@@ -15,6 +16,7 @@ namespace fakeit {
     static VerifyNoOtherInvocationsFunctor VerifyNoOtherInvocations(Fakeit);
     static UnverifiedFunctor Unverified(Fakeit);
     static SpyFunctor Spy;
+    static SpyWithoutVerifyFunctor SpyWithoutVerify;
     static FakeFunctor Fake;
     static WhenFunctor When;
 
@@ -28,6 +30,7 @@ namespace fakeit {
             use(&Fake);
             use(&When);
             use(&Spy);
+            use(&SpyWithoutVerify);
             use(&Using);
             use(&Verify);
             use(&VerifyNoOtherInvocations);

--- a/include/mockutils/type_utils.hpp
+++ b/include/mockutils/type_utils.hpp
@@ -16,6 +16,11 @@ namespace fakeit {
     template<class...>
     using fk_void_t = void;
 
+    template <bool...> struct bool_pack;
+
+    template <bool... v>
+    using all_true = std::is_same<bool_pack<true, v...>, bool_pack<v..., true>>;
+
     template<class C>
     struct naked_type {
         typedef typename std::remove_cv<typename std::remove_reference<C>::type>::type type;

--- a/tests/dtor_mocking_tests.cpp
+++ b/tests/dtor_mocking_tests.cpp
@@ -22,6 +22,7 @@ struct DtorMocking : tpunit::TestFixture
             TEST(DtorMocking::mock_virtual_dtor_by_assignment),
             TEST(DtorMocking::call_dtor_without_delete),
             TEST(DtorMocking::spy_dtor),
+            TEST(DtorMocking::spy_without_verify_dtor),
 			TEST(DtorMocking::production_takes_ownwership_with_uniqe_ptr),
 			TEST(DtorMocking::production_takes_ownership_interface_with_more_methods),
 			TEST(DtorMocking::should_fail_faking_when_no_virtual_dtor_exists)
@@ -95,6 +96,17 @@ struct DtorMocking : tpunit::TestFixture
         Verify(Dtor(mock)).Twice();
 		ASSERT_THROW(Verify(Dtor(mock)).Once(), fakeit::VerificationException);
     }
+
+	void spy_without_verify_dtor() {
+		A a;
+		Mock<A> mock(a);
+		SpyWithoutVerify(Dtor(mock));
+		A * i = &mock.get();
+		delete i;
+		delete i;
+		Verify(Dtor(mock)).Twice();
+		ASSERT_THROW(Verify(Dtor(mock)).Once(), fakeit::VerificationException);
+	}
 
 	class SomeInterface2 {
 	public:


### PR DESCRIPTION
Now `Spy()` copy arguments instead of forwarding them to the original method, so the arguments can be stored for `Verify()`ing them later. If an argument is move-only, the compiler should give a somewhat nice error message:

```
../include/fakeit/SpyFunctor.hpp:32:27: error: static assertion failed: Spy() cannot accept move-only args, use SpyWithoutVerify() instead which is able to forward these args but then they won't by available for Verify().
   32 |             static_assert(!std::is_same<R, R>::value, "Spy() cannot accept move-only args, use SpyWithoutVerify() instead which is able to forward these args but then they won't by available for Verify().");
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~                           
```

As the error message said, there is a new function `SpyWithoutVerify()` that behave as the old `Spy()`, it forward the arguments, thus making them impossible to check with the `Verify()` function later.

Should fix #191 and #205.