### PR TITLE
Fixes and workarounds for older gcc compilers

### DIFF
--- a/config/catch/CatchFakeit.hpp
+++ b/config/catch/CatchFakeit.hpp
@@ -3,15 +3,19 @@
 #include "fakeit/DefaultFakeit.hpp"
 #include "fakeit/EventHandler.hpp"
 #include "mockutils/to_string.hpp"
-#if __has_include("catch2/catch.hpp")
-#   include <catch2/catch.hpp>
-#elif __has_include("catch2/catch_all.hpp")
-#   include <catch2/catch_assertion_result.hpp>
-#   include <catch2/catch_test_macros.hpp>
-#elif __has_include("catch_amalgamated.hpp")
-#   include <catch_amalgamated.hpp>
+#if defined __has_include
+#   if __has_include("catch2/catch.hpp")
+#      include <catch2/catch.hpp>
+#   elif __has_include("catch2/catch_all.hpp")
+#      include <catch2/catch_assertion_result.hpp>
+#      include <catch2/catch_test_macros.hpp>
+#   elif __has_include("catch_amalgamated.hpp")
+#      include <catch_amalgamated.hpp>
+#   else
+#      include <catch.hpp>
+#   endif
 #else
-#   include <catch.hpp>
+#   include <catch2/catch.hpp>
 #endif
 
 namespace fakeit {

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -362,7 +362,7 @@ namespace fakeit {
         template <typename T, int N>
         struct ArgValue
         {
-            ArgValue(T &&v): value { std::forward<T>(v) } {}
+            ArgValue(T &&v): value ( std::forward<T>(v) ) {}
             constexpr static int pos = N;
             T value;
         };

--- a/include/fakeit/argument_matchers.hpp
+++ b/include/fakeit/argument_matchers.hpp
@@ -8,6 +8,7 @@
  */
 #pragma once
 
+#include <cmath>
 #include <cstring>
 
 #include "mockutils/type_utils.hpp"


### PR DESCRIPTION
I saw compilation issues when using FakeIt with a legacy project that needs gcc 4.8.5.

A problem with an ambiguous call to std::abs(double):
`g++ -flto -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -Wextra -Wno-ignored-qualifiers -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"argument_matching_tests.d" -MT"argument_matching_tests.d" -o "argument_matching_tests.o" "../tests/argument_matching_tests.cpp"
In file included from ../include/fakeit/invocation_matchers.hpp:21:0,
                 from ../include/fakeit/RecordedMethodBody.hpp:18,
                 from ../include/fakeit/StubbingImpl.hpp:15,
                 from ../include/fakeit/MockImpl.hpp:17,
                 from ../include/fakeit/Mock.hpp:11,
                 from ../include/fakeit/fakeit_root.hpp:3,
                 from ../config/standalone/fakeit.hpp:4,
                 from ../tests/argument_matching_tests.cpp:11:
../include/fakeit/argument_matchers.hpp: In instantiation of ‘bool fakeit::internal::ApproxEqCreator<ExpectedTRef, ExpectedMarginTRef>::createMatcher() const::Matcher::matches(const ActualT&) const [with ActualT = double; ExpectedTRef = int&&; ExpectedMarginTRef = double&&]’:
../include/fakeit/argument_matchers.hpp:476:17:   required from ‘fakeit::TypedMatcher<ActualT>* fakeit::internal::ApproxEqCreator<ExpectedTRef, ExpectedMarginTRef>::createMatcher() const [with ActualT = double; ExpectedTRef = int&&; ExpectedMarginTRef = double&&]’
../include/fakeit/MatchersCollector.hpp:57:104:   required from ‘typename std::enable_if<typename fakeit::naked_type<A>::type::IsTypeCompatible<typename fakeit::naked_type<typename std::tuple_element<index, std::tuple<_Elements ...> >::type>::type>::value, void>::type fakeit::MatchersCollector<index, arglist>::CollectMatchers(Head&&) [with Head = fakeit::internal::ApproxEqCreator<int&&, double&&>; unsigned int index = 0u; arglist = {double}; typename std::enable_if<typename fakeit::naked_type<A>::type::IsTypeCompatible<typename fakeit::naked_type<typename std::tuple_element<index, std::tuple<_Elements ...> >::type>::type>::value, void>::type = void]’
../include/fakeit/MethodMockingContext.hpp:260:13:   required from ‘typename std::enable_if<(sizeof (matcherCreators ...) == sizeof (arglist ...)), void>::type fakeit::MethodMockingContext<R, arglist>::setMatchingCriteria(matcherCreators&& ...) [with matcherCreators = {fakeit::internal::ApproxEqCreator<int&&, double&&>}; R = int; arglist = {double}; typename std::enable_if<(sizeof (matcherCreators ...) == sizeof (arglist ...)), void>::type = void]’
../include/fakeit/MethodMockingContext.hpp:302:112:   required from ‘fakeit::MockingContext<R, arglist>& fakeit::MockingContext<R, arglist>::Using(arg_matcher&& ...) [with arg_matcher = {fakeit::internal::ApproxEqCreator<int&&, double&&>}; R = int; arglist = {double}]’
../tests/argument_matching_tests.cpp:301:3:   required from here
../include/fakeit/argument_matchers.hpp:474:65: error: call of overloaded ‘abs(double)’ is ambiguous
                         return std::abs(actual - this->_expected) <= this->_expectedMargin;
`

There was also a problem with list-initialization used in constructor member initializer lists:
`g++ -flto -D__GXX_EXPERIMENTAL_CXX0X__ -I"../include" -I"../config/standalone" -O0 -g3 -Wall -Wextra -Wno-ignored-qualifiers -c -fmessage-length=0 -std=c++11 -MMD -MP -MF"stubbing_tests.d" -MT"stubbing_tests.d" -o "stubbing_tests.o" "../tests/stubbing_tests.cpp"
In file included from ../include/fakeit/StubbingImpl.hpp:16:0,
                 from ../include/fakeit/MockImpl.hpp:17,
                 from ../include/fakeit/Mock.hpp:11,
                 from ../include/fakeit/fakeit_root.hpp:3,
                 from ../config/standalone/fakeit.hpp:4,
                 from ../tests/stubbing_tests.cpp:13:
../include/fakeit/StubbingProgress.hpp: In instantiation of ‘fakeit::helper::ArgValue<T, N>::ArgValue(T&&) [with T = std::vector<std::basic_string<char> >&; int N = 2]’:
../include/fakeit/StubbingProgress.hpp:493:49:   required from ‘fakeit::helper::ArgValue<ArgType, std::is_placeholder<_Tp>::value> fakeit::placeholders::operator<=(PlaceHolder, ArgType&&) [with PlaceHolder = std::_Placeholder<2>; ArgType = std::vector<std::basic_string<char> >&; typename std::enable_if<static_cast<bool>(std::is_placeholder<_Tp>::value), bool>::type <anonymous> = 1u]’
../tests/stubbing_tests.cpp:203:65:   required from here
../include/fakeit/StubbingProgress.hpp:365:57: error: invalid initialization of non-const reference of type ‘std::vector<std::basic_string<char> >&’ from an rvalue of type ‘<brace-enclosed initializer list>’
             ArgValue(T &&v): value { std::forward<T>(v) } {}
                                                         ^
../include/fakeit/StubbingProgress.hpp: In instantiation of ‘fakeit::helper::ArgValue<T, N>::ArgValue(T&&) [with T = std::vector<std::basic_string<char> >&; int N = 1]’:
../include/fakeit/StubbingProgress.hpp:493:49:   required from ‘fakeit::helper::ArgValue<ArgType, std::is_placeholder<_Tp>::value> fakeit::placeholders::operator<=(PlaceHolder, ArgType&&) [with PlaceHolder = std::_Placeholder<1>; ArgType = std::vector<std::basic_string<char> >&; typename std::enable_if<static_cast<bool>(std::is_placeholder<_Tp>::value), bool>::type <anonymous> = 1u]’
../tests/stubbing_tests.cpp:213:65:   required from here
../include/fakeit/StubbingProgress.hpp:365:57: error: invalid initialization of non-const reference of type ‘std::vector<std::basic_string<char> >&’ from an rvalue of type ‘<brace-enclosed initializer list>’
make: *** [stubbing_tests.o] Error 1`

Unit tests pass with GCC 4.8.5 and 7.5.0 with these minor changes.