### PR TITLE
Take copy of return value if explicit by value used, when mocking return for return by ref or const ref method.

### DIFF
--- a/include/fakeit/ActionSequence.hpp
+++ b/include/fakeit/ActionSequence.hpp
@@ -44,7 +44,10 @@ namespace fakeit {
             Action<R, arglist...> &action = dynamic_cast<Action<R, arglist...> &>(destructable);
             std::function<void()> finallyClause = [&]() -> void {
                 if (action.isDone())
+                {
                     _recordedActions.erase(_recordedActions.begin());
+                    _usedActions.push_back(destructablePtr);
+                }
             };
             Finally onExit(finallyClause);
             return action.invoke(args);
@@ -81,6 +84,7 @@ namespace fakeit {
         }
 
         std::vector<std::shared_ptr<Destructible>> _recordedActions;
+        std::vector<std::shared_ptr<Destructible>> _usedActions;
     };
 
 }

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -53,6 +53,15 @@ namespace fakeit {
             return Do([r](const typename fakeit::test_arg<arglist>::type...) mutable -> R { return r; });
         }
 
+        template<typename T>
+        typename std::enable_if<!std::is_reference<T>::value&& std::is_copy_constructible<T>::value, MethodStubbingProgress<R, arglist...>&>::type
+            Return(T&& t) {
+            auto store = std::make_shared<T>(std::move(t));
+            return Do([store = std::move(store)](const typename fakeit::test_arg<arglist>::type...) mutable->R
+            {
+                return *store;
+            });
+        }
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -50,7 +50,7 @@ namespace fakeit {
         template<typename U = R>
         typename std::enable_if<!std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {
-            return Do([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
+            return Do([r](const typename fakeit::test_arg<arglist>::type...) mutable -> R { return r; });
         }
 
         template<typename U = R>

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -54,7 +54,7 @@ namespace fakeit {
         }
 
         template<typename T>
-        typename std::enable_if<!std::is_reference<T>::value&& std::is_copy_constructible<T>::value, MethodStubbingProgress<R, arglist...>&>::type
+        typename std::enable_if<!std::is_reference<T>::value && std::is_copy_constructible<T>::value, MethodStubbingProgress<R, arglist...>&>::type
             Return(T&& t) {
             auto store = std::make_shared<T>(std::move(t));
             return Do([store](const typename fakeit::test_arg<arglist>::type...) mutable->R
@@ -62,10 +62,16 @@ namespace fakeit {
                 return *store;
             });
         }
+
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, MethodStubbingProgress<R, arglist...> &>::type
         Return(const R &r) {
             return Do([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
+        }
+
+        typename std::enable_if<std::is_copy_constructible<R>::value, MethodStubbingProgress<R, arglist...>&>::type
+        ReturnCopy(const R& r) {
+            return Do([r](const typename fakeit::test_arg<arglist>::type...) mutable -> R { return r; });
         }
 
         MethodStubbingProgress<R, arglist...> &

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -57,7 +57,7 @@ namespace fakeit {
         typename std::enable_if<!std::is_reference<T>::value&& std::is_copy_constructible<T>::value, MethodStubbingProgress<R, arglist...>&>::type
             Return(T&& t) {
             auto store = std::make_shared<T>(std::move(t));
-            return Do([store = std::move(store)](const typename fakeit::test_arg<arglist>::type...) mutable->R
+            return Do([store](const typename fakeit::test_arg<arglist>::type...) mutable->R
             {
                 return *store;
             });

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -55,7 +55,7 @@ namespace fakeit {
 
         template<typename T>
         typename std::enable_if<!std::is_reference<T>::value && std::is_copy_constructible<T>::value, MethodStubbingProgress<R, arglist...>&>::type
-            Return(T&& t) {
+    	Return(T&& t) {
             auto store = std::make_shared<T>(std::move(t));
             return Do([store](const typename fakeit::test_arg<arglist>::type...) mutable->R
             {
@@ -71,14 +71,15 @@ namespace fakeit {
 
         template<typename U = R>
         typename std::enable_if<!std::is_copy_constructible<U>::value, MethodStubbingProgress<R, arglist...>&>::type
-            Return(R&& r) {
+    	Return(R&& r) {
             auto store = std::make_shared<R>(std::move(r)); // work around for lack of move_only_funciton( C++23) - move into a shared_ptr which we can copy.
             return Do([store](const typename fakeit::test_arg<arglist>::type...) mutable -> R {
                 return std::move(*store);
-            });
+                });
         }
 
-        typename std::enable_if<std::is_copy_constructible<R>::value, MethodStubbingProgress<R, arglist...>&>::type
+        template<typename U = R>
+        typename std::enable_if<std::is_copy_constructible<U>::value, MethodStubbingProgress<R, arglist...>&>::type
         ReturnCopy(const R& r) {
             return Do([r](const typename fakeit::test_arg<arglist>::type...) mutable -> R { return r; });
         }
@@ -120,7 +121,8 @@ namespace fakeit {
             return AlwaysDo([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
-        typename std::enable_if<std::is_copy_constructible<R>::value, void>::type
+        template<typename U = R>
+        typename std::enable_if<std::is_copy_constructible<U>::value, void>::type
             AlwaysReturnCopy(const R& r) {
             return AlwaysDo([r](const typename fakeit::test_arg<arglist>::type...) mutable -> R { return r; });
         }

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -106,10 +106,10 @@ namespace fakeit {
         }
 
         template<typename T>
-        typename std::enable_if<!std::is_reference<T>::value&& std::is_copy_constructible<T>::value, MethodStubbingProgress<R, arglist...>&>::type
+        typename std::enable_if<!std::is_reference<T>::value && std::is_copy_constructible<T>::value, void>::type
             AlwaysReturn(T&& t) {
             auto store = std::make_shared<T>(std::move(t));
-            return Do([store](const typename fakeit::test_arg<arglist>::type...) mutable->R
+            return AlwaysDo([store](const typename fakeit::test_arg<arglist>::type...) mutable -> R
                 {
                     return *store;
                 });

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -101,6 +101,11 @@ namespace fakeit {
             return AlwaysDo([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
+        typename std::enable_if<std::is_copy_constructible<R>::value, void>::type
+            AlwaysReturnCopy(const R& r) {
+            return AlwaysDo([r](const typename fakeit::test_arg<arglist>::type...) mutable -> R { return r; });
+        }
+
         MethodStubbingProgress<R, arglist...> &
         Return() {
             return Do([](const typename fakeit::test_arg<arglist>::type...) -> R { return DefaultValue<R>::value(); });

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -95,6 +95,16 @@ namespace fakeit {
             return AlwaysDo([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
+        template<typename T>
+        typename std::enable_if<!std::is_reference<T>::value&& std::is_copy_constructible<T>::value, MethodStubbingProgress<R, arglist...>&>::type
+            AlwaysReturn(T&& t) {
+            auto store = std::make_shared<T>(std::move(t));
+            return Do([store](const typename fakeit::test_arg<arglist>::type...) mutable->R
+                {
+                    return *store;
+                });
+        }
+
         template<typename U = R>
         typename std::enable_if<std::is_reference<U>::value, void>::type
         AlwaysReturn(const R &r) {

--- a/tests/referece_types_tests.cpp
+++ b/tests/referece_types_tests.cpp
@@ -49,7 +49,7 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 					//
 					TEST(ReferenceTypesTests::implicitStubbingDefaultReturnValues),
 					TEST(ReferenceTypesTests::explicitStubbingDefaultReturnValues),
-					TEST(ReferenceTypesTests::explicitStubbingReturnValuesForceCopyForRef),
+					TEST(ReferenceTypesTests::explicitStubbingReturnCopyValuesForRef),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValuesCopyForRRef),
 					TEST(ReferenceTypesTests::explicitStubbingDefaultReturnValues_with_AlwaysReturn),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValues_with_AlwaysReturn),
@@ -125,7 +125,7 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 		ASSERT_EQUAL(&c, &i.returnAbstractTypeByRef());
 	}
 
-	void explicitStubbingReturnValuesForceCopyForRef() {
+	void explicitStubbingReturnCopyValuesForRef() {
 		Mock<ReferenceInterface> mock;
 
 		// add scope so we know we are copying
@@ -134,8 +134,8 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 			int num{ 1 };
 
 			// explicit copy here
-			When(Method(mock, returnStringByConstRef)).Return<std::string>(a_string);
-			When(Method(mock, returnIntByRef)).Return<int>(num);
+			When(Method(mock, returnStringByConstRef)).ReturnCopy(a_string);
+			When(Method(mock, returnIntByRef)).ReturnCopy(num);
 
 			// modify now so know whether or not is was copied
 			a_string = "modified";

--- a/tests/referece_types_tests.cpp
+++ b/tests/referece_types_tests.cpp
@@ -48,9 +48,9 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 			tpunit::TestFixture(
 					//
 					TEST(ReferenceTypesTests::implicitStubbingDefaultReturnValues),
-					TEST(ReferenceTypesTests::explicitStubbingDefualtReturnValues),
+					TEST(ReferenceTypesTests::explicitStubbingDefaultReturnValues),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValuesForceCopyForConstRef),
-					TEST(ReferenceTypesTests::explicitStubbingDefualtReturnValues_with_AlwaysReturn),
+					TEST(ReferenceTypesTests::explicitStubbingDefaultReturnValues_with_AlwaysReturn),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValues_with_AlwaysReturn),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValues_by_assignment),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValues)
@@ -80,7 +80,7 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 		ASSERT_EQUAL(nullptr, &i.returnAbstractTypeByRef());
 	}
 
-	void explicitStubbingDefualtReturnValues() {
+	void explicitStubbingDefaultReturnValues() {
 		Mock<ReferenceInterface> mock;		//
 		When(Method(mock,returnIntByRef)).Return(); //
 		When(Method(mock,returnAbstractTypeByRef)).Return(); //
@@ -196,7 +196,7 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 		ASSERT_EQUAL(&c, &i.returnAbstractTypeByRef());
 	}
 
-	void explicitStubbingDefualtReturnValues_with_AlwaysReturn() {
+	void explicitStubbingDefaultReturnValues_with_AlwaysReturn() {
 		Mock<ReferenceInterface> mock;
 		When(Method(mock,returnIntByRef)).AlwaysReturn();
 		When(Method(mock,returnAbstractTypeByRef)).AlwaysReturn(); //

--- a/tests/referece_types_tests.cpp
+++ b/tests/referece_types_tests.cpp
@@ -53,6 +53,7 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 					TEST(ReferenceTypesTests::explicitStubbingReturnValuesCopyForRRef),
 					TEST(ReferenceTypesTests::explicitStubbingDefaultReturnValues_with_AlwaysReturn),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValues_with_AlwaysReturn),
+					TEST(ReferenceTypesTests::explicitStubbingReturnCopyValuesForRef_with_AlwaysReturn),
 					TEST(ReferenceTypesTests::explicitStubbingReturnCopyValues_with_AlwaysReturn),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValues_by_assignment),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValues)
@@ -158,6 +159,24 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 			When(Method(mock, returnStringByRef)).Return(std::string{ "myRefString" });
 			When(Method(mock, returnConcreteTypeByRef)).Return(ConcreteType(20));
 			When(Method(mock, returnIntByRef)).Return(1);
+		}
+
+		ReferenceInterface& i = mock.get();
+
+		EXPECT_EQUAL("myConstRefString", i.returnStringByConstRef());
+		EXPECT_EQUAL("myRefString", i.returnStringByRef());
+		EXPECT_EQUAL(ConcreteType(20), i.returnConcreteTypeByRef());
+		EXPECT_EQUAL(1, i.returnIntByRef());
+	}
+
+	void explicitStubbingReturnCopyValuesForRef_with_AlwaysReturn() {
+		Mock<ReferenceInterface> mock;
+
+		{
+			When(Method(mock, returnStringByConstRef)).AlwaysReturn(std::string{ "myConstRefString" });
+			When(Method(mock, returnStringByRef)).AlwaysReturn(std::string{ "myRefString" });
+			When(Method(mock, returnConcreteTypeByRef)).AlwaysReturn(ConcreteType(20));
+			When(Method(mock, returnIntByRef)).AlwaysReturn(1);
 		}
 
 		ReferenceInterface& i = mock.get();

--- a/tests/referece_types_tests.cpp
+++ b/tests/referece_types_tests.cpp
@@ -53,6 +53,7 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 					TEST(ReferenceTypesTests::explicitStubbingReturnValuesCopyForRRef),
 					TEST(ReferenceTypesTests::explicitStubbingDefaultReturnValues_with_AlwaysReturn),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValues_with_AlwaysReturn),
+					TEST(ReferenceTypesTests::explicitStubbingReturnCopyValues_with_AlwaysReturn),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValues_by_assignment),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValues)
 					//
@@ -189,6 +190,33 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 
 		// For abstract types return a reference to nullptr.
 		ASSERT_EQUAL(&c, &i.returnAbstractTypeByRef());
+	}
+	
+	void explicitStubbingReturnCopyValues_with_AlwaysReturn() {
+		Mock<ReferenceInterface> mock;
+
+		// add scope so we know we are copying
+		{
+			std::string a_string{ "myString" };
+			int num{ 1 };
+
+			// explicit copy here
+			When(Method(mock, returnStringByConstRef)).AlwaysReturnCopy(a_string);
+			When(Method(mock, returnIntByRef)).AlwaysReturnCopy(num);
+
+			// modify now so know whether or not is was copied
+			a_string = "modified";
+			num = 2;
+		}
+
+		ReferenceInterface& i = mock.get();
+
+		// Fundamental types are initiated to 0.
+		EXPECT_EQUAL("myString", i.returnStringByConstRef());
+		EXPECT_EQUAL("myString", i.returnStringByConstRef());
+
+		EXPECT_EQUAL(1, i.returnIntByRef());
+		EXPECT_EQUAL(1, i.returnIntByRef());
 	}
 
 	void explicitStubbingReturnValues_by_assignment() {

--- a/tests/referece_types_tests.cpp
+++ b/tests/referece_types_tests.cpp
@@ -40,6 +40,8 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 		virtual int& returnIntByRef() = 0;
 		virtual AbstractType& returnAbstractTypeByRef() = 0;
 		virtual ConcreteType& returnConcreteTypeByRef() = 0;
+		virtual const std::string& returnStringByConstRef() = 0;
+
 	};
 
 	ReferenceTypesTests() :
@@ -47,6 +49,7 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 					//
 					TEST(ReferenceTypesTests::implicitStubbingDefaultReturnValues),
 					TEST(ReferenceTypesTests::explicitStubbingDefualtReturnValues),
+					TEST(ReferenceTypesTests::explicitStubbingReturnValuesForceCopyForConstRef),
 					TEST(ReferenceTypesTests::explicitStubbingDefualtReturnValues_with_AlwaysReturn),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValues_with_AlwaysReturn),
 					TEST(ReferenceTypesTests::explicitStubbingReturnValues_by_assignment),
@@ -119,6 +122,30 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 
 		// For abstract types return a reference to nullptr.
 		ASSERT_EQUAL(&c, &i.returnAbstractTypeByRef());
+	}
+
+	void explicitStubbingReturnValuesForceCopyForConstRef() {
+		Mock<ReferenceInterface> mock;
+
+		// add scope so we know we are copying
+		{
+			std::string a_string{"myString"};
+			int num{ 1 };
+
+			// explicit copy here
+			When(Method(mock, returnStringByConstRef)).Return<std::string>(a_string);
+			When(Method(mock, returnIntByRef)).Return<int>(num);
+
+			// modify now so know whether or not is was copied
+			a_string = "modified";
+			num = 2;
+		}
+
+		ReferenceInterface& i = mock.get();
+
+		// Fundamental types are initiated to 0.
+		ASSERT_EQUAL("myString", i.returnStringByConstRef());
+		ASSERT_EQUAL(1, i.returnIntByRef());
 	}
 
 	void explicitStubbingReturnValues_with_AlwaysReturn() {


### PR DESCRIPTION
For issue https://github.com/eranpeer/FakeIt/issues/258