### PR TITLE
Enable stubbing of move only return values.

### DIFF
--- a/build/sources.mk
+++ b/build/sources.mk
@@ -11,6 +11,7 @@ CPP_SRCS += \
 	gcc_stubbing_multiple_values_tests.cpp \
 	gcc_type_info_tests.cpp \
 	miscellaneous_tests.cpp \
+	move_only_return_tests.cpp \
 	msc_stubbing_multiple_values_tests.cpp \
 	msc_type_info_tests.cpp \
 	overloadded_methods_tests.cpp \

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -59,6 +59,15 @@ namespace fakeit {
             return Do([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
         }
 
+        template<typename U = R>
+        typename std::enable_if<!std::is_copy_constructible<U>::value, MethodStubbingProgress<R, arglist...>&>::type
+            Return(R&& r) {
+            auto store = std::make_shared<R>(std::move(r)); // work around for lack of move_only_funciton( C++23) - move into a shared_ptr which we can copy.
+            return Do([store = std::move(store)](const typename fakeit::test_arg<arglist>::type...) mutable -> R {
+                return std::move(*store);
+            });
+        }
+
         MethodStubbingProgress<R, arglist...> &
         Return(const Quantifier<R> &q) {
             const R &value = q.value;

--- a/tests/all_tests.vcxproj
+++ b/tests/all_tests.vcxproj
@@ -133,6 +133,7 @@
     <ClCompile Include="gcc_stubbing_multiple_values_tests.cpp" />
     <ClCompile Include="gcc_type_info_tests.cpp" />
     <ClCompile Include="miscellaneous_tests.cpp" />
+    <ClCompile Include="move_only_return_tests.cpp" />
     <ClCompile Include="msc_stubbing_multiple_values_tests.cpp" />
     <ClCompile Include="msc_type_info_tests.cpp" />
     <ClCompile Include="overloadded_methods_tests.cpp" />

--- a/tests/move_only_return_tests.cpp
+++ b/tests/move_only_return_tests.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2014 Eran Pe'er.
+ *
+ * This program is made available under the terms of the MIT License.
+ *
+ * Created on Mar 10, 2014
+ */
+
+#include <string>
+#include <queue>
+
+#include "tpunit++.hpp"
+#include "fakeit.hpp"
+
+using namespace fakeit;
+
+struct MoveOnlyReturnTests: tpunit::TestFixture {
+
+	class AbstractType {
+	public:
+		virtual void foo() = 0;
+	};
+
+	class ConcreteType: public AbstractType {
+	public:
+		int state;
+		ConcreteType(int value) :
+				state(value) {
+		}
+		ConcreteType(const ConcreteType&) = delete;
+		ConcreteType(ConcreteType&&) = default;
+
+		virtual void foo() override {
+		}
+
+		bool operator==(const ConcreteType& other) {
+			return (other.state == this->state);
+		}
+
+	};
+
+	struct ReferenceInterface {
+		virtual std::unique_ptr<std::string> returnMoveOnlyUniqueString() = 0;
+		virtual ConcreteType returnMoveOnlyConcreteTypeByRef() = 0;
+	};
+
+	MoveOnlyReturnTests() :
+			tpunit::TestFixture(
+					//
+					TEST(MoveOnlyReturnTests::explicitStubbingReturnValuesFromTemporary),
+					TEST(MoveOnlyReturnTests::explicitStubbingReturnValuesFromMove)
+					//
+							) {
+	}
+
+	void explicitStubbingReturnValuesFromTemporary() {
+		Mock<ReferenceInterface> mock;
+
+		When(Method(mock, returnMoveOnlyUniqueString)).Return(std::unique_ptr<std::string>(new std::string("value")));
+		When(Method(mock, returnMoveOnlyConcreteTypeByRef)).Return(ConcreteType(10));
+
+		ReferenceInterface & i = mock.get();
+
+		ASSERT_EQUAL("value", *i.returnMoveOnlyUniqueString());
+
+		ASSERT_EQUAL(ConcreteType(10), i.returnMoveOnlyConcreteTypeByRef());
+	}
+
+	void explicitStubbingReturnValuesFromMove() {
+		Mock<ReferenceInterface> mock;
+
+		ConcreteType c(10);
+		std::unique_ptr<std::string> string(new std::string("value"));
+
+		When(Method(mock, returnMoveOnlyUniqueString)).Return(std::move(string));
+		When(Method(mock, returnMoveOnlyConcreteTypeByRef)).Return(std::move(c));
+
+		ASSERT_FALSE(string); // check move did happen
+
+		ReferenceInterface& i = mock.get();
+
+		ASSERT_EQUAL(std::string("value"), *i.returnMoveOnlyUniqueString());
+
+		ASSERT_EQUAL(ConcreteType(10), i.returnMoveOnlyConcreteTypeByRef());
+	}
+} __MoveOnlyReturnTests;
+


### PR DESCRIPTION
Implementation for this:
https://github.com/eranpeer/FakeIt/issues/281