### PR TITLE
Call default mock method for virtual destructor

### DIFF
--- a/tests/dtor_mocking_tests.cpp
+++ b/tests/dtor_mocking_tests.cpp
@@ -17,7 +17,8 @@ struct DtorMocking : tpunit::TestFixture
 {
 	DtorMocking() :
 		TestFixture(
-            TEST(DtorMocking::mock_virtual_dtor_with_fake), //
+            TEST(DtorMocking::mock_virtual_dtor_no_mocks),
+            TEST(DtorMocking::mock_virtual_dtor_with_fake),
 		    TEST(DtorMocking::mock_virtual_dtor_with_when),
             TEST(DtorMocking::mock_virtual_dtor_by_assignment),
             TEST(DtorMocking::call_dtor_without_delete),
@@ -35,6 +36,12 @@ struct DtorMocking : tpunit::TestFixture
 	{
 		virtual ~SomeInterface() = default;
 	};
+
+	void mock_virtual_dtor_no_mocks() {
+		Mock<SomeInterface> mock;
+		SomeInterface* i = &(mock.get());
+		delete i;
+	}
 
 	void mock_virtual_dtor_with_fake() {
 		Mock<SomeInterface> mock;


### PR DESCRIPTION
Make sure we copy and use the default mock destructor from the default virtual function table.

It seems it sets the default VTable up by default to call `unmockedDtor()`, but then makes a new VTable for the specific object but doesn't copy it across.

Seems to only be an issue on windows

A general work around is:
```
Fake(Dtor(mock));
// or When(Dtor(mock)).Do([](auto){} );
```

Another one for shared_ptr is this
```
shared_ptr ptr( &mock.get(), [](auto) {} );
```


Issue here:
https://github.com/eranpeer/FakeIt/issues/288