### PR TITLE
Enable compiling with Visual Studio 2019 v142

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ Debug/
 ipch/
 TestResults/
 tests/cmake-build-debug/
+tests/x64/
 */.vs/
 
 # Eclipse
@@ -59,3 +60,4 @@ bii/
 
 *.*~
 *.nupkg
+

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,2 +1,10 @@
+image:
+- Visual Studio 2019
+- Visual Studio 2015
+
+configuration:
+- Debug
+- Release
+
 build:
   project: tests\all_tests.sln

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -425,7 +425,7 @@ namespace fakeit {
         struct ArgLocator {
             template<typename current_arg, typename ...T, int ...N>
             static void AssignArg(current_arg &&p, std::tuple<ArgValue<T, N>...> arg_vals) {
-#if __cplusplus >= 201703L
+#if __cplusplus >= 201703L && !defined (_WIN32)
                 if constexpr (std::get<check_index>(arg_vals).pos == arg_index)
                     GetArg(std::forward<current_arg>(p)) = std::get<check_index>(arg_vals).value;
 #else
@@ -436,7 +436,7 @@ namespace fakeit {
                     ArgLocator<arg_index, check_index - 1>::AssignArg(std::forward<current_arg>(p), arg_vals);
             }
 
-#if __cplusplus < 201703L
+#if __cplusplus < 201703L || defined (_WIN32)
         private:
             template<typename T, typename U>
             static

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -373,7 +373,7 @@ namespace fakeit {
             template <typename ...T, int ...N>
             static void CheckPositions(const std::tuple<ArgValue<T, N>...> arg_vals)
             {
-#if __cplusplus >= 201402L
+#if __cplusplus >= 201402L && !defined(_WIN32)
                 static_assert(std::get<tuple_index>(arg_vals).pos <= max_index,
                     "Argument index out of range");
                 ArgValidator<max_index, tuple_index - 1>::CheckPositions(arg_vals);

--- a/tests/all_tests.vcxproj
+++ b/tests/all_tests.vcxproj
@@ -26,26 +26,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v140</PlatformToolset>
+    <PlatformToolset>v142</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/tests/all_tests.vcxproj
+++ b/tests/all_tests.vcxproj
@@ -26,26 +26,26 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
-    <PlatformToolset>v142</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/tests/all_tests.vcxproj
+++ b/tests/all_tests.vcxproj
@@ -72,7 +72,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include;..\config\standalone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/bigobj</AdditionalOptions>
+      <AdditionalOptions>/bigobj /Zc:__cplusplus</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -84,7 +84,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include;..\config\standalone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/bigobj</AdditionalOptions>
+      <AdditionalOptions>/bigobj /Zc:__cplusplus</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -98,6 +98,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include;..\config\standalone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/bigobj /Zc:__cplusplus</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -113,6 +114,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include;..\config\standalone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalOptions>/bigobj /Zc:__cplusplus</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/tests/all_tests.vcxproj
+++ b/tests/all_tests.vcxproj
@@ -21,6 +21,7 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7944BCE9-8B9D-4B89-9259-703B7E2EAE22}</ProjectGuid>
     <RootNamespace>all_tests</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
@@ -119,6 +120,12 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <ClCompile Condition="'$(PlatformToolset)' != 'v140'">
+      <AdditionalOptions>/Zc:__cplusplus</AdditionalOptions>
+      <LanguageStandard>stdcpp20</LanguageStandard>
+    </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="argument_matching_tests.cpp" />

--- a/tests/all_tests.vcxproj
+++ b/tests/all_tests.vcxproj
@@ -21,7 +21,6 @@
   <PropertyGroup Label="Globals">
     <ProjectGuid>{7944BCE9-8B9D-4B89-9259-703B7E2EAE22}</ProjectGuid>
     <RootNamespace>all_tests</RootNamespace>
-    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/tests/all_tests.vcxproj
+++ b/tests/all_tests.vcxproj
@@ -72,7 +72,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include;..\config\standalone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/bigobj /Zc:__cplusplus</AdditionalOptions>
+      <AdditionalOptions>/bigobj</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -84,7 +84,7 @@
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include;..\config\standalone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/bigobj /Zc:__cplusplus</AdditionalOptions>
+      <AdditionalOptions>/bigobj</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -98,7 +98,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include;..\config\standalone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/bigobj /Zc:__cplusplus</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -114,7 +113,6 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
       <AdditionalIncludeDirectories>..\include;..\config\standalone;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalOptions>/bigobj /Zc:__cplusplus</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/tests/cpp14_tests.cpp
+++ b/tests/cpp14_tests.cpp
@@ -71,10 +71,12 @@ struct Cpp14Tests : tpunit::TestFixture {
 				), fakeit::VerificationException);
 	}
 
+	struct ApiInterface {
+		virtual bool apiMethod(int a, int b, int& result) = 0;
+	};
+
     void assingOutParamsWithLambdaCpp14(){
-        struct ApiInterface {
-            virtual bool apiMethod(int a, int b, int& result) = 0;
-        };
+
 
         Mock<ApiInterface> mock;
         When(Method(mock, apiMethod)).AlwaysDo([](auto a, auto b, auto& result) {

--- a/tests/miscellaneous_tests.cpp
+++ b/tests/miscellaneous_tests.cpp
@@ -48,16 +48,17 @@ struct Miscellaneous : tpunit::TestFixture
         Fake(Method(mock, foo));
     }
 
+    struct SomeClass
+    {
+        virtual void foo() = 0;
+    protected:
+        SomeClass(int)
+        {
+        }
+    };
+
     void can_mock_class_with_protected_constructor()
     {
-        struct SomeClass
-        {
-            virtual void foo() = 0;
-        protected:
-            SomeClass(int)
-            {
-            }
-        };
         Mock<SomeClass> mock;
         Fake(Method(mock, foo));
     }
@@ -121,14 +122,15 @@ struct Miscellaneous : tpunit::TestFixture
         ASSERT_EQUAL(4, mock().a2());
     }
 
+    struct FooReturnInt {
+        virtual int bar(int&&) = 0;
+    };
 
     void testStubFuncWithRightValueParameter() {
 
-        struct Foo {
-            virtual int bar(int &&) = 0;
-        };
 
-        Mock<Foo> foo_mock;
+
+        Mock<FooReturnInt> foo_mock;
         When(Method(foo_mock, bar)).AlwaysReturn(100);
         When(Method(foo_mock, bar).Using(1)).AlwaysReturn(1);
         When(Method(foo_mock, bar).Using(2)).AlwaysDo([](int &){return 2; });
@@ -142,17 +144,17 @@ struct Miscellaneous : tpunit::TestFixture
         ASSERT_EQUAL(4, foo_mock.get().bar(4));
     }
 
-    void testStubProcWithRightValueParameter() {
+    struct FooReturnVoid {
+        virtual void bar(int&&) = 0;
+    };
 
-        struct Foo {
-            virtual void bar(int &&) = 0;
-        };
+    void testStubProcWithRightValueParameter() {
 
         int rv3 = 0;
         int rv4 = 0;
         int rv5 = 0;
 
-        Mock<Foo> foo_mock;
+        Mock<FooReturnVoid> foo_mock;
         When(Method(foo_mock, bar).Using(1)).Return();
         When(Method(foo_mock, bar)).AlwaysReturn();
         When(Method(foo_mock, bar).Using(3)).AlwaysDo([&](int &){rv3 = 3; });

--- a/tests/stubbing_tests.cpp
+++ b/tests/stubbing_tests.cpp
@@ -765,20 +765,21 @@ struct BasicStubbing : tpunit::TestFixture {
         ASSERT_THROW(i.func(1), fakeit::UnexpectedMethodCallException);
     }
 
+    struct SomeInterfaceWithMember {
+        virtual int func(int) = 0;
+
+        std::string state;
+    };
 
     void reset_mock_to_initial_state() {
-        struct SomeInterface {
-            virtual int func(int) = 0;
 
-            std::string state;
-        };
 
-        Mock<SomeInterface> mock;
+        Mock<SomeInterfaceWithMember> mock;
         When(Method(mock, func)).AlwaysReturn(0);
         When(Method(mock, func).Using(1)).AlwaysReturn(1);
-        mock.Stub(&SomeInterface::state, "state");
+        mock.Stub(&SomeInterfaceWithMember::state, "state");
 //
-        SomeInterface &i = mock.get();
+        SomeInterfaceWithMember&i = mock.get();
         i.func(0);
         i.func(1);
 
@@ -805,10 +806,12 @@ struct BasicStubbing : tpunit::TestFixture {
         Verify(Method(mock, func).Using(1));
     }
 
+    struct SomeClass {
+        virtual int foo(int* x) = 0;
+    };
+
     void use_lambda_to_change_ptr_value() {
-        struct SomeClass {
-            virtual int foo(int *x) = 0;
-        };
+
 
         Mock<SomeClass> mock;
 
@@ -823,10 +826,11 @@ struct BasicStubbing : tpunit::TestFixture {
         ASSERT_EQUAL(1, num);
     }
 
-    void assingOutParamsWithLambda(){
-        struct ApiInterface {
-            virtual bool apiMethod(int a, int b, int& result) = 0;
-        };
+    struct ApiInterface {
+        virtual bool apiMethod(int a, int b, int& result) = 0;
+    };
+	void assingOutParamsWithLambda(){
+
 
         Mock<ApiInterface> mock;
         When(Method(mock, apiMethod)).AlwaysDo([](int a, int b, int& result) {

--- a/tests/verification_tests.cpp
+++ b/tests/verification_tests.cpp
@@ -494,12 +494,11 @@ struct BasicVerification: tpunit::TestFixture {
 		Verify(2 * call_to_proc2_with_state_1);
 	}
 
+	struct AnInterface {
+		virtual int func(int) = 0;
+	};
 
 	void verifyWithUnverifiedFunctor(){
-
-        struct AnInterface {
-            virtual int func(int) = 0;
-        };
         
         Mock<AnInterface> mock;
 		When(Method(mock, func)).AlwaysReturn(0);
@@ -523,10 +522,6 @@ struct BasicVerification: tpunit::TestFixture {
 
 	void verifyWithUnverifiedFunctorWithUsing() {
 
-		struct AnInterface {
-			virtual int func(int) = 0;
-		};
-
 		Mock<AnInterface> mock;
 		When(Method(mock, func)).AlwaysReturn(0);
 
@@ -538,10 +533,6 @@ struct BasicVerification: tpunit::TestFixture {
 	}
 
 	void verificationProgressShouldBeConvertibleToBool(){
-
-		struct AnInterface {
-			virtual int func(int) = 0;
-		};
 
 		Mock<AnInterface> mock;
 		When(Method(mock, func)).AlwaysReturn(0);
@@ -574,11 +565,13 @@ struct BasicVerification: tpunit::TestFixture {
 		ASSERT_FALSE(!VerifyNoOtherInvocations(Method(mock, func)));
     }
 
+	struct RefEater {
+		virtual int eatChar(char*) = 0;
+		virtual int eatConstChar(const char*) = 0;
+	};
+
 	void verificationShouldTolerateNullString(){
-		struct RefEater {
-			virtual int eatChar(char*) = 0;
-			virtual int eatConstChar(const char*) = 0;
-		};
+
 
 		Mock<RefEater> mock;
 		When( Method( mock, eatChar ) ).AlwaysReturn( 0 );


### PR DESCRIPTION
Not sure if this is the best approach, but Visual Studio 2019 (v142 toolset) complains about local class definitions which have pure virtual methods
- compile switch to give std behaviour for __cplusplus macro
- re-disable check which is not working for VS
- disabled some constexpr that isn't working for windows.