### PR TITLE
Handle stubbing modern C++ ref overloades - partial

### DIFF
--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -57,6 +57,7 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
+        // const non void
         template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
@@ -64,6 +65,7 @@ namespace fakeit {
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
+        // volatile non void
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
@@ -71,6 +73,7 @@ namespace fakeit {
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
+        // const volatile non void
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
@@ -78,10 +81,43 @@ namespace fakeit {
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
+        // non void
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
                 !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
         MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
             return impl.template stubMethod<id>(vMethod);
+        }
+
+        // ref non void
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+            !std::is_void<R>::value&& std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stub(R(T::* vMethod)(arglist...) &) {
+            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        // const ref non void
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+            !std::is_void<R>::value&& std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stub(R(T::* vMethod)(arglist...) const&) {
+            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        // rref non void
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+            !std::is_void<R>::value&& std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stub(R(T::* vMethod)(arglist...) &&) {
+            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
+        }
+
+        // const rref non void
+        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
+            !std::is_void<R>::value&& std::is_base_of<T, C>::value>::type>
+        MockingContext<R, arglist...> stub(R(T::* vMethod)(arglist...) const&&) {
+            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+            return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<

--- a/include/fakeit/Prototype.hpp
+++ b/include/fakeit/Prototype.hpp
@@ -12,20 +12,47 @@ namespace fakeit {
 
         typedef R ConstType(Args...) const;
 
-        template<class C>
+        typedef R RefType(Args...) &;
+
+        typedef R ConstRefType(Args...) const&;
+
+    	typedef R RRefType(Args...) &&;
+
+        typedef R ConstRRefType(Args...) const&&;
+
+    	template<class C>
         struct MemberType {
 
             typedef Type(C::*type);
-            typedef ConstType(C::*cosntType);
+            typedef ConstType(C::* constType);
+            typedef RefType(C::* refType);
+            typedef ConstRefType(C::* constRefType);
+            typedef RRefType(C::* rRefType);
+            typedef ConstRRefType(C::* constRRefType);
 
             static type get(type t) {
                 return t;
             }
 
-            static cosntType getconst(cosntType t) {
+            static constType getconst(constType t) {
                 return t;
             }
 
+            static refType getRef(refType t) {
+                return t;
+            }
+
+            static constRefType getConstRef(constRefType t) {
+                return t;
+            }
+
+            static rRefType getRRef(rRefType t) {
+                return t;
+            }
+
+            static constRRefType getConstRRef(constRRefType t) {
+                return t;
+            }
         };
 
     };

--- a/include/fakeit/api_macros.hpp
+++ b/include/fakeit/api_macros.hpp
@@ -13,6 +13,18 @@
 #define CONST_OVERLOADED_METHOD_PTR(mock, method, prototype) \
     fakeit::Prototype<prototype>::MemberType<typename MOCK_TYPE(mock)>::getconst(&MOCK_TYPE(mock)::method)
 
+#define REF_OVERLOADED_METHOD_PTR(mock, method, prototype) \
+    fakeit::Prototype<prototype>::MemberType<typename MOCK_TYPE(mock)>::getRef(&MOCK_TYPE(mock)::method)
+
+#define CONST_REF_OVERLOADED_METHOD_PTR(mock, method, prototype) \
+    fakeit::Prototype<prototype>::MemberType<typename MOCK_TYPE(mock)>::getConstRef(&MOCK_TYPE(mock)::method)
+
+#define RREF_OVERLOADED_METHOD_PTR(mock, method, prototype) \
+    fakeit::Prototype<prototype>::MemberType<typename MOCK_TYPE(mock)>::getRRef(&MOCK_TYPE(mock)::method)
+
+#define CONST_RREF_OVERLOADED_METHOD_PTR(mock, method, prototype) \
+    fakeit::Prototype<prototype>::MemberType<typename MOCK_TYPE(mock)>::getConstRRef(&MOCK_TYPE(mock)::method)
+
 #define Dtor(mock) \
     (mock).dtor().setMethodDetails(#mock,"destructor")
 
@@ -24,6 +36,19 @@
 
 #define ConstOverloadedMethod(mock, method, prototype) \
     (mock).template stub<__COUNTER__>(CONST_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+
+#define RefOverloadedMethod(mock, method, prototype) \
+    (mock).template stub<__COUNTER__>(REF_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+
+#define ConstRefOverloadedMethod(mock, method, prototype) \
+    (mock).template stub<__COUNTER__>(CONST_REF_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+
+#define RRefOverloadedMethod(mock, method, prototype) \
+    (mock).template stub<__COUNTER__>(RREF_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+
+#define ConstRRefOverloadedMethod(mock, method, prototype) \
+    (mock).template stub<__COUNTER__>(CONST_RREF_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
+
 
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)

--- a/tests/overloadded_methods_tests.cpp
+++ b/tests/overloadded_methods_tests.cpp
@@ -40,7 +40,11 @@ struct OverloadedMethods : tpunit::TestFixture {
             tpunit::TestFixture(
                     TEST(OverloadedMethods::stub_overloaded_methods),
                     TEST(OverloadedMethods::stub_const_overloaded_methods),
-                    TEST(OverloadedMethods::stub_overloaded_methods_with_templates<SomeInterface>)) {
+                    TEST(OverloadedMethods::stub_overloaded_methods_with_templates<SomeInterface>),
+                    TEST(OverloadedMethods::stub_modern_overloaded_methods),
+                    TEST(OverloadedMethods::stub_modern_rref_overloaded_method),
+                    TEST(OverloadedMethods::stub_modern_constrref_overloaded_method)
+            ) {
     }
 
     void stub_overloaded_methods() {
@@ -92,6 +96,48 @@ struct OverloadedMethods : tpunit::TestFixture {
         When(OverloadedMethod(mock, func, int(int))).AlwaysReturn(45);
 
         ASSERT_EQUAL(45, i.func(1));
+    }
+
+    struct SomeModernCppInterface {
+
+        virtual int func() & = 0;
+
+        virtual int func(int) & = 0;
+        virtual int func(int) const& = 0;
+        virtual int func(int) && = 0;
+        virtual int func(int) const&& = 0;
+    };
+
+    void stub_modern_overloaded_methods() {
+
+        Mock<SomeModernCppInterface> mock;
+        When(RefOverloadedMethod(mock, func, int(int))).Return(1);
+        When(ConstRefOverloadedMethod(mock, func, int(int))).Return(2);
+
+        SomeModernCppInterface& refObj = mock.get();
+        const SomeModernCppInterface& refConstObj = mock.get();
+
+        ASSERT_EQUAL(1, refObj.func(1));
+        ASSERT_EQUAL(2, refConstObj.func(1));
+    }
+
+    void stub_modern_rref_overloaded_method() {
+
+        Mock<SomeModernCppInterface> mock;
+        When(RRefOverloadedMethod(mock, func, int(int))).Return(3);
+
+        SomeModernCppInterface& refObj = mock.get();
+
+        ASSERT_EQUAL(3, std::move(refObj).func(1));
+    }
+
+    void stub_modern_constrref_overloaded_method() {
+
+        Mock<SomeModernCppInterface> mock;
+        When(ConstRRefOverloadedMethod(mock, func, int(int))).Return(4);
+
+        const SomeModernCppInterface& refConstObj = mock.get();
+        ASSERT_EQUAL(4, std::move(refConstObj).func(1));
     }
 
 } __OverloadedMethods;


### PR DESCRIPTION
Partial fix for https://github.com/eranpeer/FakeIt/issues/292
- does non-void returning cases - stubs