### PR TITLE
Fix ReturnAndSet for convertible variables that are not assignable

### DIFF
--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -449,7 +449,7 @@ namespace fakeit {
         private:
             template<typename T, typename U>
             static
-            typename std::enable_if<std::is_convertible<U, decltype(GetArg(std::declval<T>()))>::value, void>::type
+            typename std::enable_if<std::is_assignable<decltype(GetArg(std::declval<T>())), U>::value, void>::type
             Set(T &&p, U &&v)
             {
                 GetArg(std::forward<T>(p)) = v;
@@ -457,7 +457,7 @@ namespace fakeit {
 
             template<typename T, typename U>
             static
-            typename std::enable_if<!std::is_convertible<U, decltype(GetArg(std::declval<T>()))>::value, void>::type
+            typename std::enable_if<!std::is_assignable<decltype(GetArg(std::declval<T>())), U>::value, void>::type
             Set(T &&, U &&)
             {
                 throw std::logic_error("ReturnAndSet(): Invalid value type");

--- a/tests/stubbing_tests.cpp
+++ b/tests/stubbing_tests.cpp
@@ -26,6 +26,7 @@ struct BasicStubbing : tpunit::TestFixture {
                     TEST(BasicStubbing::stub_a_function_to_return_a_specified_value_always),
                     TEST(BasicStubbing::stub_a_function_to_set_specified_values_once),
                     TEST(BasicStubbing::stub_a_function_to_set_specified_values_once_form2),
+                    TEST(BasicStubbing::stub_a_function_to_set_specified_values_once_form2_convertible_not_assignable),
                     TEST(BasicStubbing::stub_a_function_to_set_specified_value_with_incompatible_params),
                     TEST(BasicStubbing::stub_a_function_to_set_specified_values_always),
                     TEST(BasicStubbing::stub_a_function_to_set_specified_values_always_form2),
@@ -61,10 +62,12 @@ struct BasicStubbing : tpunit::TestFixture {
         virtual int func(int) = 0;
         virtual int funcNoArgs() = 0;
         virtual int funcRefArgs(int*, int&) = 0;
+        virtual int funcConvertibleNotAssignableArgs1(int&, int) = 0;
 
         virtual void proc(int) = 0;
         virtual void procRefArgs(int*, int&) = 0;
         virtual void procIncompatArgs(std::string&, std::vector<std::string>&) = 0;
+        virtual void procConvertibleNotAssignableArgs2(int, int&) = 0;
     };
 
     void calling_an_unstubbed_method_should_raise_UnmockedMethodCallException() {
@@ -194,6 +197,28 @@ struct BasicStubbing : tpunit::TestFixture {
             i.procRefArgs(&a, b);
             FAIL();
         } catch (fakeit::UnexpectedMethodCallException &) {
+        }
+    }
+
+    void stub_a_function_to_set_specified_values_once_form2_convertible_not_assignable() {
+        Mock<SomeInterface> mock;
+        When(Method(mock, funcConvertibleNotAssignableArgs1)).ReturnAndSet(1, _1 <= 3);
+        When(Method(mock, procConvertibleNotAssignableArgs2)).ReturnAndSet(_2 <= 5);
+
+        SomeInterface &i = mock.get();
+
+        {
+            int a1 = 0, b1 = 0;
+            ASSERT_EQUAL(1, i.funcConvertibleNotAssignableArgs1(a1, b1));
+            ASSERT_EQUAL(3, a1);
+            ASSERT_EQUAL(0, b1);
+        }
+
+        {
+            int a2 = 0, b2 = 0;
+            i.procConvertibleNotAssignableArgs2(a2, b2);
+            ASSERT_EQUAL(0, a2);
+            ASSERT_EQUAL(5, b2);
         }
     }
 


### PR DESCRIPTION
Should fix #278.