### PR TITLE
Fix msvc Spy() and destructor mocking

### DIFF
--- a/include/mockutils/Finally.hpp
+++ b/include/mockutils/Finally.hpp
@@ -3,7 +3,7 @@
  * Copyright (c) 2014 Eran Pe'er.
  *
  * This program is made available under the terms of the MIT License.
- * 
+ *
  * Created on Aug 30, 2014
  */
 #pragma once
@@ -16,13 +16,17 @@ namespace fakeit {
     private:
         std::function<void()> _finallyClause;
 
-        Finally(const Finally &);
+        Finally(const Finally &) = delete;
 
-        Finally &operator=(const Finally &);
+        Finally &operator=(const Finally &) = delete;
 
     public:
         explicit Finally(std::function<void()> f) :
                 _finallyClause(f) {
+        }
+
+        Finally(Finally&& other) {
+             _finallyClause.swap(other._finallyClause);
         }
 
         ~Finally() {

--- a/include/mockutils/MethodProxyCreator.hpp
+++ b/include/mockutils/MethodProxyCreator.hpp
@@ -34,6 +34,11 @@ namespace fakeit {
             return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyX < id > ));
         }
 
+        template<unsigned int id>
+        MethodProxy createMethodProxyStatic(unsigned int offset) {
+            return MethodProxy(id, offset, union_cast<void *>(&MethodProxyCreator::methodProxyXStatic < id > ));
+        }
+
     protected:
 
         R methodProxy(unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
@@ -48,6 +53,20 @@ namespace fakeit {
         template<int id>
         R methodProxyX(arglist ... args) {
             return methodProxy(id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
+        }
+
+        static R methodProxyStatic(void* instance, unsigned int id, const typename fakeit::production_arg<arglist>::type... args) {
+            InvocationHandlerCollection *invocationHandlerCollection = InvocationHandlerCollection::getInvocationHandlerCollection(
+                instance);
+            MethodInvocationHandler<R, arglist...> *invocationHandler =
+                (MethodInvocationHandler<R, arglist...> *) invocationHandlerCollection->getInvocatoinHandlerPtrById(
+                    id);
+            return invocationHandler->handleMethodInvocation(std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
+        }
+
+        template<int id>
+        static R methodProxyXStatic(void* instance, arglist ... args) {
+            return methodProxyStatic(instance, id, std::forward<const typename fakeit::production_arg<arglist>::type>(args)...);
         }
     };
 }

--- a/tests/spying_tests.cpp
+++ b/tests/spying_tests.cpp
@@ -30,7 +30,8 @@ struct SpyingTests: tpunit::TestFixture {
 					TEST(SpyingTests::spyThenVerifyValueArg),
 					TEST(SpyingTests::spyMoveOnlyPassedByRef),
 					TEST(SpyingTests::spyMoveOnlyWithoutVerify),
-					TEST(SpyingTests::spyVectorOfMoveOnly)
+					TEST(SpyingTests::spyVectorOfMoveOnly),
+					TEST(SpyingTests::spyWorksWithDerivedClasses)
 					//
 	) //
 	{
@@ -50,9 +51,12 @@ struct SpyingTests: tpunit::TestFixture {
 		virtual int func1(int arg) {
 			return arg;
 		}
-		virtual int func2(int arg) {
-			return arg;
-		}
+                virtual int func2(int arg) {
+                        return arg;
+                }
+                virtual int func3(int arg) {
+                        return arg;
+                }
 		virtual void proc(){
 		}
 		virtual std::string funcTakeByValue(std::string arg) {
@@ -72,6 +76,19 @@ struct SpyingTests: tpunit::TestFixture {
 			return sum;
 		}
 	};
+
+        class DerivedClass : public SomeClass {
+        public:
+                int func1(int arg) override {
+                        return arg * 2;
+                }
+                int func2(int arg) override {
+                        return arg * 2;
+                }
+                int func3(int arg) override {
+                        return arg * 2;
+                }
+        };
 
 	void useOriginalClassMethodIfNotFaked() {
 		SomeClass obj;
@@ -260,6 +277,21 @@ struct SpyingTests: tpunit::TestFixture {
 
 		SomeClass &i = mock.get();
 		ASSERT_EQUAL(15, i.funcVectorOfMoveOnly(testutils::multi_emplace(std::vector<MoveOnlyType>{}, MoveOnlyType{5}, MoveOnlyType{10})));
+	}
+
+	void spyWorksWithDerivedClasses() {
+		DerivedClass derived;
+		SomeClass& objRef = derived;
+		Mock<SomeClass> spy(objRef);
+		Spy(Method(spy,func1));
+		Fake(Method(spy,func2));
+		ASSERT_EQUAL(2, objRef.func1(1)); // spied, should call original
+		ASSERT_EQUAL(0, objRef.func2(1)); // mocked, should call default impl
+		ASSERT_EQUAL(2, objRef.func3(1)); // not spied nor mocked, should call original
+
+		Verify(Method(spy,func1).Using(1)).Once();
+		Verify(Method(spy,func2).Using(1)).Once();
+		VerifyNoOtherInvocations(spy);
 	}
 
 } __SpyingTests;


### PR DESCRIPTION
Should close #54, #131 and #279.

Basically we call some member function like `memberPtr(instance)` at some places instead of doing `(instance->*memberPtr)()`. It worked with GCC / Clang but not with MSVC (sometimes it worked but it wasn't 100% reliable). Two of these places where when spying functions and mocking destructors. I removed these to use the correct form of calling instead.

I found one more usage of the wrong form of calling, it's for the default destructor (and only for MSVC), but because it's a member function that takes no argument and return nothing and do nothing it seems to be fine.