### PR TITLE
Added a lot more configurations in the CI, and fixed some stuff.

### DIFF
--- a/.github/workflows/ci_linux_clang.yml
+++ b/.github/workflows/ci_linux_clang.yml
@@ -9,24 +9,73 @@ defaults:
     shell: bash
 
 jobs:
-  clang-ubuntu-20-04:
-    runs-on: ubuntu-20.04
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+            name: "Ubuntu 20.04 Clang 10",
+            os: ubuntu-20.04,
+            build_type: Debug,
+            cc: "clang-10", cxx: "clang++-10"
+          }
+          - {
+            name: "Ubuntu 20.04 Clang 11",
+            os: ubuntu-20.04,
+            build_type: Debug,
+            cc: "clang-11", cxx: "clang++-11"
+          }
+          - {
+            name: "Ubuntu 20.04 Clang 12",
+            os: ubuntu-20.04,
+            build_type: Debug,
+            cc: "clang-12", cxx: "clang++-12"
+          }
+          - {
+            name: "Ubuntu 22.04 Clang 13",
+            os: ubuntu-22.04,
+            build_type: Debug,
+            cc: "clang-13", cxx: "clang++-13"
+          }
+          - {
+            name: "Ubuntu 22.04 Clang 14 C++11",
+            os: ubuntu-22.04,
+            build_type: Debug,
+            cc: "clang-14", cxx: "clang++-14",
+            cxx_standard: 11
+          }
+          - {
+            name: "Ubuntu 22.04 Clang 14 C++14",
+            os: ubuntu-22.04,
+            build_type: Debug,
+            cc: "clang-14", cxx: "clang++-14",
+            cxx_standard: 14
+          }
+          - {
+            name: "Ubuntu 22.04 Clang 14 C++17",
+            os: ubuntu-22.04,
+            build_type: Debug,
+            cc: "clang-14", cxx: "clang++-14",
+            cxx_standard: 17
+          }
+          - {
+            name: "Ubuntu 22.04 Clang 14 C++20",
+            os: ubuntu-22.04,
+            build_type: Debug,
+            cc: "clang-14", cxx: "clang++-14",
+            cxx_standard: 20
+          }
     steps:
       - uses: actions/checkout@v2
       - name: Build project
+        env:
+          CC: ${{ matrix.config.cc }}
+          CXX: ${{ matrix.config.cxx }}
         run: |
-          CC=clang CXX=clang++ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
-          cmake --build build -j
-      - name: Run tests
-        run: |
-          build/tests/FakeIt_tests
-  clang-ubuntu-18-04:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build project
-        run: |
-          CC=clang CXX=clang++ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DENABLE_TESTING=ON -DOVERRIDE_CXX_STANDARD_FOR_TESTS=${{ matrix.config.cxx_standard }}
           cmake --build build -j
       - name: Run tests
         run: |

--- a/.github/workflows/ci_linux_gcc.yml
+++ b/.github/workflows/ci_linux_gcc.yml
@@ -9,48 +9,67 @@ defaults:
     shell: bash
 
 jobs:
-  coverage:
-    runs-on: ubuntu-20.04
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+            name: "Ubuntu 20.04 GCC 9",
+            os: ubuntu-20.04,
+            build_type: Debug,
+            cc: "gcc-9", cxx: "g++-9"
+          }
+          - {
+            name: "Ubuntu 20.04 GCC 10",
+            os: ubuntu-20.04,
+            build_type: Debug,
+            cc: "gcc-10", cxx: "g++-10"
+          }
+          - {
+            name: "Ubuntu 22.04 GCC 11",
+            os: ubuntu-22.04,
+            build_type: Debug,
+            cc: "gcc-11", cxx: "g++-11"
+          }
+          - {
+            name: "Ubuntu 22.04 GCC 12 C++11",
+            os: ubuntu-22.04,
+            build_type: Debug,
+            cc: "gcc-12", cxx: "g++-12",
+            cxx_standard: 11
+          }
+          - {
+            name: "Ubuntu 22.04 GCC 12 C++14",
+            os: ubuntu-22.04,
+            build_type: Debug,
+            cc: "gcc-12", cxx: "g++-12",
+            cxx_standard: 14
+          }
+          - {
+            name: "Ubuntu 22.04 GCC 12 C++17",
+            os: ubuntu-22.04,
+            build_type: Debug,
+            cc: "gcc-12", cxx: "g++-12",
+            cxx_standard: 17
+          }
+          - {
+            name: "Ubuntu 22.04 GCC 12 C++20",
+            os: ubuntu-22.04,
+            build_type: Debug,
+            cc: "gcc-12", cxx: "g++-12",
+            cxx_standard: 20
+          }
     steps:
-      - name: Install LCOV
-        run: sudo apt install -y lcov
       - uses: actions/checkout@v2
       - name: Build project
+        env:
+          CC: ${{ matrix.config.cc }}
+          CXX: ${{ matrix.config.cxx }}
         run: |
-          CC=gcc CXX=g++ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_COVERAGE=ON
-          cmake --build build -j
-      - name: Run tests
-        run: |
-          build/tests/FakeIt_tests
-      - name: Generate report
-        run: |
-          cd build/tests/CMakeFiles/FakeIt_tests.dir
-          gcov *.o
-          lcov --directory . -c -o report.info
-          lcov --remove report.info '/usr/*' '*/tests/*' -o report_filtered.info
-      - name: Upload report
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: ./build/tests/CMakeFiles/FakeIt_tests.dir/report_filtered.info
-  gcc-ubuntu-20-04:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build project
-        run: |
-          CC=gcc CXX=g++ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
-          cmake --build build -j
-      - name: Run tests
-        run: |
-          build/tests/FakeIt_tests
-  gcc-ubuntu-18-04:
-    runs-on: ubuntu-18.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build project
-        run: |
-          CC=gcc CXX=g++ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=${{ matrix.config.build_type }} -DENABLE_TESTING=ON -DOVERRIDE_CXX_STANDARD_FOR_TESTS=${{ matrix.config.cxx_standard }}
           cmake --build build -j
       - name: Run tests
         run: |

--- a/.github/workflows/ci_windows_msvc.yml
+++ b/.github/workflows/ci_windows_msvc.yml
@@ -9,25 +9,58 @@ defaults:
     shell: bash
 
 jobs:
-  msvc-windows-2022:
-    runs-on: windows-2022
+  build:
+    name: ${{ matrix.config.name }}
+    runs-on: ${{ matrix.config.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {
+            name: "Windows 2019 MSVC 2019 Win32",
+            os: windows-2019,
+            build_type: Debug,
+            generator: "Visual Studio 16 2019",
+            architecture: "Win32"
+          }
+          - {
+            name: "Windows 2022 MSVC 2022 Win32 C++11",
+            os: windows-2022,
+            build_type: Debug,
+            generator: "Visual Studio 17 2022",
+            architecture: "Win32",
+            cxx_standard: 11
+          }
+          - {
+            name: "Windows 2022 MSVC 2022 Win32 C++14",
+            os: windows-2022,
+            build_type: Debug,
+            generator: "Visual Studio 17 2022",
+            architecture: "Win32",
+            cxx_standard: 14
+          }
+          - {
+            name: "Windows 2022 MSVC 2022 Win32 C++17",
+            os: windows-2022,
+            build_type: Debug,
+            generator: "Visual Studio 17 2022",
+            architecture: "Win32",
+            cxx_standard: 17
+          }
+          - {
+            name: "Windows 2022 MSVC 2022 Win32 C++20",
+            os: windows-2022,
+            build_type: Debug,
+            generator: "Visual Studio 17 2022",
+            architecture: "Win32",
+            cxx_standard: 20
+          }
     steps:
       - uses: actions/checkout@v2
       - name: Build project
         run: |
-          cmake -S . -B build -G "Visual Studio 17 2022"
-          cmake --build build --config Debug -j
+          cmake -S . -B build -G "${{ matrix.config.generator }}" -A ${{ matrix.config.architecture }} -DENABLE_TESTING=ON -DOVERRIDE_CXX_STANDARD_FOR_TESTS=${{ matrix.config.cxx_standard }}
+          cmake --build build --config ${{ matrix.config.build_type }} -j
       - name: Run tests
         run: |
-          echo "Not yet because bugged but it needs to be fixed."
-  msvc-windows-2019:
-    runs-on: windows-2019
-    steps:
-      - uses: actions/checkout@v2
-      - name: Build project
-        run: |
-          cmake -S . -B build -G "Visual Studio 16 2019"
-          cmake --build build --config Debug -j
-      - name: Run tests
-        run: |
-          echo "Not yet because bugged but it needs to be fixed."
+          build/tests/Debug/FakeIt_tests.exe

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,38 @@
+name: Coverage
+
+on:
+  push:
+  pull_request:
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  coverage:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Install LCOV
+        run: sudo apt install -y lcov
+      - uses: actions/checkout@v2
+      - name: Build project
+        env:
+          CC: gcc-9
+          CXX: g++-9
+        run: |
+          cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=ON -DENABLE_COVERAGE=ON
+          cmake --build build -j
+      - name: Run tests
+        run: |
+          build/tests/FakeIt_tests
+      - name: Generate report
+        run: |
+          cd build/tests/CMakeFiles/FakeIt_tests.dir
+          gcov-9 *.o
+          lcov --gcov-tool gcov-9 --directory . -c -o report.info
+          lcov --gcov-tool gcov-9 --remove report.info '/usr/*' '*/tests/*' -o report_filtered.info
+      - name: Upload report
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: ./build/tests/CMakeFiles/FakeIt_tests.dir/report_filtered.info

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ cmake_minimum_required(VERSION 3.14)
 project(FakeIt VERSION 2.3.2 LANGUAGES CXX)
 
 option(ENABLE_COVERAGE "Enable coverage reporting for gcc/clang." OFF)
+option(ENABLE_TESTING "Enable build of tests." OFF)
+option(OVERRIDE_CXX_STANDARD_FOR_TESTS "Override the C++ standard used for building tests." "")
 
 # Directory containing main targets of FakeIt.
 add_subdirectory(include)
@@ -11,8 +13,10 @@ add_subdirectory(include)
 # Directory containing config targets of FakeIt.
 add_subdirectory(config)
 
-# Directory containing test targets of FakeIt.
-add_subdirectory(tests)
+if(ENABLE_TESTING)
+    # Directory containing test targets of FakeIt.
+    add_subdirectory(tests)
+endif()
 
 # Directory containing single header targets of FakeIt.
 add_subdirectory(single_header)

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ For GCC, it is recommended to build the test project with -O1 or -O0 flags. Some
 
 #### Building and Running the Unit Tests with GCC
 ```
-CC=gcc CXX=g++ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+CC=gcc CXX=g++ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=ON
 cmake --build build -j
 ```
 Run the tests by typing:
@@ -134,7 +134,7 @@ Run the tests by typing:
 
 #### Building and Running the Unit Tests with Clang
 ```
-CC=clang CXX=clang++ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug
+CC=clang CXX=clang++ cmake -S . -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_TESTING=ON
 cmake --build build -j
 ```
 Run the tests by typing:
@@ -144,7 +144,7 @@ Run the tests by typing:
 
 #### Building and Running the Unit Tests with Visual Studio 
 ```
-cmake -S . -B build -G "Visual Studio 17 2022"
+cmake -S . -B build -G "Visual Studio 17 2022" -DENABLE_TESTING=ON
 cmake --build build --config Debug -j
 ```
 Run the tests by typing:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,1 @@
+build: off

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -40,6 +40,11 @@ elseif(MSVC)
     target_compile_options(FakeIt_tests PRIVATE /W3 /sdl /Od)
 endif()
 
+if(OVERRIDE_CXX_STANDARD_FOR_TESTS)
+    set_target_properties(FakeIt_tests PROPERTIES CXX_STANDARD ${OVERRIDE_CXX_STANDARD_FOR_TESTS})
+    message(STATUS "Building tests in C++${OVERRIDE_CXX_STANDARD_FOR_TESTS}.")
+endif()
+
 if(ENABLE_COVERAGE)
     if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "^(Apple)?Clang$")
         target_compile_options(FakeIt_tests PRIVATE --coverage)


### PR DESCRIPTION
- Added more versions of GCC and Clang.
- Tests now run for MSVC.
- Test several C++ standard instead of only the default one of the compiler.
- Test are not ran by default, their building need to be enabled manually.
- Disabled appveyor.

MSVC tests run in 32 bits, because the 64 bits mode doesn't work with RTTI related features : #196.
MSVC tests currently don't run C++14-specific tests, even if compiled in C++14. I guess it's because of the thing about `__cplusplus` define not being defined but I'm not sure.

Will fix parts of #269.