### PR TITLE
Handling stub of ref-qualified overloads

### DIFF
--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -14,8 +14,23 @@
 
 namespace fakeit {
     namespace internal {
+        template<typename T, typename = void>
+        struct WithCommonVoid {
+            using type = T;
+        };
+
+        // The goal of this specialization is to replace all kinds of void (e.g. "const void") by a common type, "void".
+        // This is because some other parts of the code have specialization for "void", but these specializations only
+        // handle "void", and not "const void", so instead of modifying all these specialization to handle both types,
+        // we replace "const void" by "void" here.
+        template<typename T>
+        struct WithCommonVoid<T, typename std::enable_if<std::is_void<T>::value, void>::type> {
+            using type = void;
+        };
+
+        template<typename T>
+        using WithCommonVoid_t = typename WithCommonVoid<T>::type;
     }
-    using namespace fakeit::internal;
 
     template<typename C, typename ... baseclasses>
     class Mock : public ActualInvocationsSource {
@@ -38,7 +53,7 @@ namespace fakeit {
 //		std::shared_ptr<C> getShared() {
 //			return impl.getShared();
 //		}
-        
+
 		C &operator()() {
             return get();
         }
@@ -57,94 +72,67 @@ namespace fakeit {
             return impl.stubDataMember(member, ctorargs...);
         }
 
-        // const non void
+        // const
         template<int id, typename R, typename T, typename ... arglist, class = typename std::enable_if<
-                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R (T::*vMethod)(arglist...) const) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R (T::*)(arglist...)>(vMethod);
+                std::is_base_of<T, C>::value>::type>
+        MockingContext<internal::WithCommonVoid_t<R>, arglist...> stub(R (T::*vMethod)(arglist...) const) {
+            auto methodWithoutConstVolatile = reinterpret_cast<internal::WithCommonVoid_t<R> (T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        // volatile non void
+        // volatile
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+                std::is_base_of<T, C>::value>::type>
+        MockingContext<internal::WithCommonVoid_t<R>, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
+            auto methodWithoutConstVolatile = reinterpret_cast<internal::WithCommonVoid_t<R>(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        // const volatile non void
+        // const volatile
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+                std::is_base_of<T, C>::value>::type>
+        MockingContext<internal::WithCommonVoid_t<R>, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
+            auto methodWithoutConstVolatile = reinterpret_cast<internal::WithCommonVoid_t<R>(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        // non void
+        // no qualifier
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                !std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::*vMethod)(arglist...)) {
-            return impl.template stubMethod<id>(vMethod);
-        }
-
-        // ref non void
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-            !std::is_void<R>::value&& std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::* vMethod)(arglist...) &) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+                std::is_base_of<T, C>::value>::type>
+        MockingContext<internal::WithCommonVoid_t<R>, arglist...> stub(R(T::*vMethod)(arglist...)) {
+            auto methodWithoutConstVolatile = reinterpret_cast<internal::WithCommonVoid_t<R>(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        // const ref non void
+        // ref
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-            !std::is_void<R>::value&& std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::* vMethod)(arglist...) const&) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+                std::is_base_of<T, C>::value>::type>
+        MockingContext<internal::WithCommonVoid_t<R>, arglist...> stub(R(T::*vMethod)(arglist...) &) {
+            auto methodWithoutConstVolatile = reinterpret_cast<internal::WithCommonVoid_t<R>(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        // rref non void
+        // const ref
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-            !std::is_void<R>::value&& std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::* vMethod)(arglist...) &&) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+                std::is_base_of<T, C>::value>::type>
+        MockingContext<internal::WithCommonVoid_t<R>, arglist...> stub(R(T::*vMethod)(arglist...) const&) {
+            auto methodWithoutConstVolatile = reinterpret_cast<internal::WithCommonVoid_t<R>(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
-        // const rref non void
+        // rref
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-            !std::is_void<R>::value&& std::is_base_of<T, C>::value>::type>
-        MockingContext<R, arglist...> stub(R(T::* vMethod)(arglist...) const&&) {
-            auto methodWithoutConstVolatile = reinterpret_cast<R(T::*)(arglist...)>(vMethod);
+                std::is_base_of<T, C>::value>::type>
+        MockingContext<internal::WithCommonVoid_t<R>, arglist...> stub(R(T::*vMethod)(arglist...) &&) {
+            auto methodWithoutConstVolatile = reinterpret_cast<internal::WithCommonVoid_t<R>(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 
+        // const rref
         template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const) {
-            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
-
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) volatile) {
-            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
-
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...) const volatile) {
-            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
-            return impl.template stubMethod<id>(methodWithoutConstVolatile);
-        }
-
-        template<int id, typename R, typename T, typename... arglist, class = typename std::enable_if<
-                std::is_void<R>::value && std::is_base_of<T, C>::value>::type>
-        MockingContext<void, arglist...> stub(R(T::*vMethod)(arglist...)) {
-            auto methodWithoutConstVolatile = reinterpret_cast<void (T::*)(arglist...)>(vMethod);
+                std::is_base_of<T, C>::value>::type>
+        MockingContext<internal::WithCommonVoid_t<R>, arglist...> stub(R(T::*vMethod)(arglist...) const&&) {
+            auto methodWithoutConstVolatile = reinterpret_cast<internal::WithCommonVoid_t<R>(T::*)(arglist...)>(vMethod);
             return impl.template stubMethod<id>(methodWithoutConstVolatile);
         }
 

--- a/include/fakeit/Prototype.hpp
+++ b/include/fakeit/Prototype.hpp
@@ -8,51 +8,40 @@ namespace fakeit {
     template<typename R, typename... Args>
     struct Prototype<R(Args...)> {
 
-        typedef R Type(Args...);
-
-        typedef R ConstType(Args...) const;
-
-        typedef R RefType(Args...) &;
-
-        typedef R ConstRefType(Args...) const&;
-
-    	typedef R RRefType(Args...) &&;
-
-        typedef R ConstRRefType(Args...) const&&;
-
-    	template<class C>
+        template<class C>
         struct MemberType {
 
-            typedef Type(C::*type);
-            typedef ConstType(C::* constType);
-            typedef RefType(C::* refType);
-            typedef ConstRefType(C::* constRefType);
-            typedef RRefType(C::* rRefType);
-            typedef ConstRRefType(C::* constRRefType);
+            using Type = R (C::*)(Args...);
+            using ConstType = R (C::*)(Args...) const;
+            using RefType = R (C::*)(Args...) &;
+            using ConstRefType = R (C::*)(Args...) const&;
+            using RRefType = R (C::*)(Args...) &&;
+            using ConstRRefType = R (C::*)(Args...) const&&;
 
-            static type get(type t) {
+            static Type get(Type t) {
                 return t;
             }
 
-            static constType getconst(constType t) {
+            static ConstType getConst(ConstType t) {
                 return t;
             }
 
-            static refType getRef(refType t) {
+            static RefType getRef(RefType t) {
                 return t;
             }
 
-            static constRefType getConstRef(constRefType t) {
+            static ConstRefType getConstRef(ConstRefType t) {
                 return t;
             }
 
-            static rRefType getRRef(rRefType t) {
+            static RRefType getRRef(RRefType t) {
                 return t;
             }
 
-            static constRRefType getConstRRef(constRRefType t) {
+            static ConstRRefType getConstRRef(ConstRRefType t) {
                 return t;
             }
+
         };
 
     };
@@ -73,4 +62,3 @@ namespace fakeit {
     };
 
 }
-

--- a/include/fakeit/api_macros.hpp
+++ b/include/fakeit/api_macros.hpp
@@ -11,7 +11,7 @@
     fakeit::Prototype<prototype>::template MemberType<typename MOCK_TYPE(mock)>::get(&MOCK_TYPE(mock)::method)
 
 #define CONST_OVERLOADED_METHOD_PTR(mock, method, prototype) \
-    fakeit::Prototype<prototype>::template MemberType<typename MOCK_TYPE(mock)>::getconst(&MOCK_TYPE(mock)::method)
+    fakeit::Prototype<prototype>::template MemberType<typename MOCK_TYPE(mock)>::getConst(&MOCK_TYPE(mock)::method)
 
 #define REF_OVERLOADED_METHOD_PTR(mock, method, prototype) \
     fakeit::Prototype<prototype>::MemberType<typename MOCK_TYPE(mock)>::getRef(&MOCK_TYPE(mock)::method)
@@ -64,4 +64,3 @@
 
 #define When(call) \
     When(call)
-

--- a/include/fakeit/api_macros.hpp
+++ b/include/fakeit/api_macros.hpp
@@ -49,7 +49,6 @@
 #define ConstRRefOverloadedMethod(mock, method, prototype) \
     (mock).template stub<__COUNTER__>(CONST_RREF_OVERLOADED_METHOD_PTR( mock , method, prototype )).setMethodDetails(#mock,#method)
 
-
 #define Verify(...) \
         Verify( __VA_ARGS__ ).setFileInfo(__FILE__, __LINE__, __func__)
 

--- a/tests/overloadded_methods_tests.cpp
+++ b/tests/overloadded_methods_tests.cpp
@@ -99,7 +99,6 @@ struct OverloadedMethods : tpunit::TestFixture {
     }
 
     struct SomeModernCppInterface {
-
         virtual int func() & = 0;
 
         virtual int func(int) & = 0;
@@ -109,7 +108,6 @@ struct OverloadedMethods : tpunit::TestFixture {
     };
 
     void stub_modern_overloaded_methods() {
-
         Mock<SomeModernCppInterface> mock;
         When(RefOverloadedMethod(mock, func, int(int))).Return(1);
         When(ConstRefOverloadedMethod(mock, func, int(int))).Return(2);
@@ -117,27 +115,41 @@ struct OverloadedMethods : tpunit::TestFixture {
         SomeModernCppInterface& refObj = mock.get();
         const SomeModernCppInterface& refConstObj = mock.get();
 
-        ASSERT_EQUAL(1, refObj.func(1));
-        ASSERT_EQUAL(2, refConstObj.func(1));
+        ASSERT_EQUAL(1, refObj.func(10));
+        ASSERT_EQUAL(2, refConstObj.func(20));
+
+        Verify(RefOverloadedMethod(mock, func, int(int)).Using(10)).Exactly(1);
+        Verify(ConstRefOverloadedMethod(mock, func, int(int)).Using(20)).Exactly(1);
+
+        VerifyNoOtherInvocations(mock);
     }
 
     void stub_modern_rref_overloaded_method() {
-
         Mock<SomeModernCppInterface> mock;
+        When(RefOverloadedMethod(mock, func, int(int))).Return(1);
         When(RRefOverloadedMethod(mock, func, int(int))).Return(3);
 
         SomeModernCppInterface& refObj = mock.get();
 
+        ASSERT_EQUAL(1, refObj.func(1));
         ASSERT_EQUAL(3, std::move(refObj).func(1));
+
+        Verify(RefOverloadedMethod(mock, func, int(int))).Exactly(1);
+        Verify(RRefOverloadedMethod(mock, func, int(int))).Exactly(1);
+
+        VerifyNoOtherInvocations(mock);
     }
 
     void stub_modern_constrref_overloaded_method() {
-
         Mock<SomeModernCppInterface> mock;
         When(ConstRRefOverloadedMethod(mock, func, int(int))).Return(4);
 
         const SomeModernCppInterface& refConstObj = mock.get();
         ASSERT_EQUAL(4, std::move(refConstObj).func(1));
+
+        Verify(ConstRRefOverloadedMethod(mock, func, int(int)).Using(1)).Exactly(1);
+
+        VerifyNoOtherInvocations(mock);
     }
 
 } __OverloadedMethods;


### PR DESCRIPTION
Based on #309, complete the implementation by having it working on GCC and handling void-functions. Should close #292.