### PR TITLE
Fix some warnings.

### DIFF
--- a/config/standalone/StandaloneFakeit.hpp
+++ b/config/standalone/StandaloneFakeit.hpp
@@ -6,7 +6,7 @@
 namespace fakeit {
 
     struct VerificationException : public std::exception {
-        virtual ~VerificationException() FAKEIT_NO_THROWS{};
+        ~VerificationException() FAKEIT_NO_THROWS override {};
         
         VerificationException(std::string format) : //
             _format(format) { //
@@ -33,7 +33,7 @@ namespace fakeit {
             return _callingMethod;
         }
 
-        const char* what() const FAKEIT_NO_THROWS override{
+        const char* what() const FAKEIT_NO_THROWS override {
             return _format.c_str();
         }
     private:
@@ -71,20 +71,20 @@ namespace fakeit {
             : _formatter(formatter) {
         }
 
-        virtual void handle(const UnexpectedMethodCallEvent &evt) override {
+        void handle(const UnexpectedMethodCallEvent &evt) override {
             std::string format = _formatter.format(evt);
             UnexpectedMethodCallException ex(format);
             throw ex;
         }
 
-        virtual void handle(const SequenceVerificationEvent &evt) override {
+        void handle(const SequenceVerificationEvent &evt) override {
             std::string format(formatLineNumner(evt.file(), evt.line()) + ": " + _formatter.format(evt));
             SequenceVerificationException e(format);
             e.setFileInfo(evt.file(), evt.line(), evt.callingMethod());
             throw e;
         }
 
-        virtual void handle(const NoMoreInvocationsVerificationEvent &evt) override {
+        void handle(const NoMoreInvocationsVerificationEvent &evt) override {
             std::string format(formatLineNumner(evt.file(), evt.line()) + ": " + _formatter.format(evt));
             NoMoreInvocationsVerificationException e(format);
             e.setFileInfo(evt.file(), evt.line(), evt.callingMethod());
@@ -98,7 +98,7 @@ namespace fakeit {
     class StandaloneFakeit : public DefaultFakeit {
 
     public:
-        virtual ~StandaloneFakeit() = default;
+        ~StandaloneFakeit() override = default;
 
         StandaloneFakeit() : _standaloneAdapter(*this) {
         }

--- a/include/fakeit/Action.hpp
+++ b/include/fakeit/Action.hpp
@@ -40,12 +40,12 @@ namespace fakeit {
                 f(func), times(t) {
         }
 
-        virtual R invoke(const ArgumentsTuple<arglist...> & args) override {
+        R invoke(const ArgumentsTuple<arglist...> & args) override {
             times--;
             return TupleDispatcher::invoke<R, arglist...>(f, args);
         }
 
-        virtual bool isDone() override {
+        bool isDone() override {
             return times == 0;
         }
 
@@ -63,11 +63,11 @@ namespace fakeit {
                 f(func) {
         }
 
-        virtual R invoke(const ArgumentsTuple<arglist...> & args) override {
+        R invoke(const ArgumentsTuple<arglist...> & args) override {
             return TupleDispatcher::invoke<R, arglist...>(f, args);
         }
 
-        virtual bool isDone() override {
+        bool isDone() override {
             return false;
         }
 
@@ -79,11 +79,11 @@ namespace fakeit {
     struct ReturnDefaultValue : public Action<R, arglist...> {
         virtual ~ReturnDefaultValue() = default;
 
-        virtual R invoke(const ArgumentsTuple<arglist...> &) override {
+        R invoke(const ArgumentsTuple<arglist...> &) override {
             return DefaultValue<R>::value();
         }
 
-        virtual bool isDone() override {
+        bool isDone() override {
             return false;
         }
     };
@@ -95,11 +95,11 @@ namespace fakeit {
 
         virtual ~ReturnDelegateValue() = default;
 
-        virtual R invoke(const ArgumentsTuple<arglist...> & args) override {
+        R invoke(const ArgumentsTuple<arglist...> & args) override {
             return TupleDispatcher::invoke<R, arglist...>(_delegate, args);
         }
 
-        virtual bool isDone() override {
+        bool isDone() override {
             return false;
         }
 

--- a/include/fakeit/ActionSequence.hpp
+++ b/include/fakeit/ActionSequence.hpp
@@ -37,7 +37,7 @@ namespace fakeit {
             append(action);
         }
 
-        virtual R handleMethodInvocation(ArgumentsTuple<arglist...> & args) override
+        R handleMethodInvocation(ArgumentsTuple<arglist...> & args) override
         {
             std::shared_ptr<Destructible> destructablePtr = _recordedActions.front();
             Destructible &destructable = *destructablePtr;
@@ -63,11 +63,11 @@ namespace fakeit {
 //                throw NoMoreRecordedActionException();
 //            }
 
-            virtual R invoke(const ArgumentsTuple<arglist...> &) override {
+            R invoke(const ArgumentsTuple<arglist...> &) override {
                 throw NoMoreRecordedActionException();
             }
 
-            virtual bool isDone() override {
+            bool isDone() override {
                 return false;
             }
         };

--- a/include/fakeit/ActualInvocation.hpp
+++ b/include/fakeit/ActualInvocation.hpp
@@ -54,7 +54,7 @@ namespace fakeit {
             return _matcher;
         }
 
-        virtual std::string format() const override {
+        std::string format() const override {
             std::ostringstream out;
             out << getMethod().name();
             print(out, actualArguments);

--- a/include/fakeit/DefaultEventFormatter.hpp
+++ b/include/fakeit/DefaultEventFormatter.hpp
@@ -15,7 +15,7 @@ namespace fakeit {
 
     struct DefaultEventFormatter : public EventFormatter {
 
-        virtual std::string format(const UnexpectedMethodCallEvent &e) override {
+        std::string format(const UnexpectedMethodCallEvent &e) override {
             std::ostringstream out;
             out << "Unexpected method invocation: ";
             out << e.getInvocation().format() << std::endl;
@@ -34,7 +34,7 @@ namespace fakeit {
          Actual matches  : 0
          Actual sequence : no actual invocations
          */
-        virtual std::string format(const SequenceVerificationEvent &e) override {
+        std::string format(const SequenceVerificationEvent &e) override {
             std::ostringstream out;
             out << "Verification error" << std::endl;
 
@@ -60,7 +60,7 @@ namespace fakeit {
             return out.str();
         }
 
-        virtual std::string format(const NoMoreInvocationsVerificationEvent &e) override {
+        std::string format(const NoMoreInvocationsVerificationEvent &e) override {
             std::ostringstream out;
             out << "Verification error" << std::endl;
             out << "Expected no more invocations!! but the following unverified invocations were found:" << std::endl;

--- a/include/fakeit/DefaultEventLogger.hpp
+++ b/include/fakeit/DefaultEventLogger.hpp
@@ -18,15 +18,15 @@ namespace fakeit {
 
         DefaultEventLogger(EventFormatter &formatter) : _formatter(formatter), _out(std::cout) { }
 
-        virtual void handle(const UnexpectedMethodCallEvent &e) override {
+        void handle(const UnexpectedMethodCallEvent &e) override {
             _out << _formatter.format(e) << std::endl;
         }
 
-        virtual void handle(const SequenceVerificationEvent &e) override {
+        void handle(const SequenceVerificationEvent &e) override {
             _out << _formatter.format(e) << std::endl;
         }
 
-        virtual void handle(const NoMoreInvocationsVerificationEvent &e) override {
+        void handle(const NoMoreInvocationsVerificationEvent &e) override {
             _out << _formatter.format(e) << std::endl;
         }
 

--- a/include/fakeit/DefaultFakeit.hpp
+++ b/include/fakeit/DefaultFakeit.hpp
@@ -14,7 +14,7 @@ namespace fakeit {
 
     class AbstractFakeit : public FakeitContext {
     public:
-        virtual ~AbstractFakeit() = default;
+        ~AbstractFakeit() override = default;
 
     protected:
 
@@ -35,7 +35,7 @@ namespace fakeit {
                           _testingFrameworkAdapter(nullptr) {
         }
 
-        virtual ~DefaultFakeit() = default;
+        ~DefaultFakeit() override = default;
 
         void setCustomEventFormatter(fakeit::EventFormatter &customEventFormatter) {
             _customFormatter = &customEventFormatter;

--- a/include/fakeit/FakeitEvents.hpp
+++ b/include/fakeit/FakeitEvents.hpp
@@ -62,7 +62,7 @@ namespace fakeit {
 
     struct NoMoreInvocationsVerificationEvent : public VerificationEvent {
 
-        ~NoMoreInvocationsVerificationEvent() = default;
+        ~NoMoreInvocationsVerificationEvent() override = default;
 
         NoMoreInvocationsVerificationEvent( //
                 std::vector<Invocation *> &allTheIvocations, //
@@ -87,7 +87,7 @@ namespace fakeit {
 
     struct SequenceVerificationEvent : public VerificationEvent {
 
-        ~SequenceVerificationEvent() = default;
+        ~SequenceVerificationEvent() override = default;
 
         SequenceVerificationEvent(VerificationType aVerificationType, //
                                   std::vector<Sequence *> &anExpectedPattern, //

--- a/include/fakeit/FakeitExceptions.hpp
+++ b/include/fakeit/FakeitExceptions.hpp
@@ -46,7 +46,7 @@ namespace fakeit {
                 _format(format) {
         }
 
-        virtual std::string what() const override {
+        std::string what() const override {
             return _format;
         }
 

--- a/include/fakeit/Invocation.hpp
+++ b/include/fakeit/Invocation.hpp
@@ -39,7 +39,7 @@ namespace fakeit {
                 _ordinal(ordinal), _method(method), _isVerified(false) {
         }
 
-        virtual ~Invocation() override = default;
+        ~Invocation() override = default;
 
         unsigned int getOrdinal() const {
             return _ordinal;

--- a/include/fakeit/MethodMockingContext.hpp
+++ b/include/fakeit/MethodMockingContext.hpp
@@ -182,7 +182,7 @@ namespace fakeit {
                 : _impl(std::move(other._impl)) {
         }
 
-        virtual ~MethodMockingContext() FAKEIT_NO_THROWS { }
+        ~MethodMockingContext() FAKEIT_NO_THROWS override { }
 
         std::string format() const override {
             return _impl->format();

--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -36,7 +36,7 @@ namespace fakeit {
     class Mock : public ActualInvocationsSource {
         MockImpl<C, baseclasses...> impl;
     public:
-        virtual ~Mock() = default;
+        ~Mock() override = default;
 
         static_assert(std::is_polymorphic<C>::value, "Can only mock a polymorphic type");
 

--- a/include/fakeit/MockImpl.hpp
+++ b/include/fakeit/MockImpl.hpp
@@ -37,7 +37,7 @@ namespace fakeit {
             fake->getVirtualTable().setCookie(1, this);
         }
 
-        virtual ~MockImpl() FAKEIT_NO_THROWS {
+        ~MockImpl() FAKEIT_NO_THROWS override {
             _proxy.detach();
         }
 
@@ -75,11 +75,11 @@ namespace fakeit {
 			initDataMembersIfOwner();
         }
 
-        virtual C &get() override {
+        C &get() override {
             return _proxy.get();
         }
 
-        virtual FakeitContext &getFakeIt() override {
+        FakeitContext &getFakeIt() override {
             return _fakeit;
         }
 
@@ -141,27 +141,27 @@ namespace fakeit {
             virtual ~MethodMockingContextBase() = default;
 
             void addMethodInvocationHandler(typename ActualInvocation<arglist...>::Matcher *matcher,
-                ActualInvocationHandler<R, arglist...> *invocationHandler) {
+                ActualInvocationHandler<R, arglist...> *invocationHandler) override {
                 getRecordedMethodBody().addMethodInvocationHandler(matcher, invocationHandler);
             }
 
-            void scanActualInvocations(const std::function<void(ActualInvocation<arglist...> &)> &scanner) {
+            void scanActualInvocations(const std::function<void(ActualInvocation<arglist...> &)> &scanner) override {
                 getRecordedMethodBody().scanActualInvocations(scanner);
             }
 
-            void setMethodDetails(std::string mockName, std::string methodName) {
+            void setMethodDetails(std::string mockName, std::string methodName) override {
                 getRecordedMethodBody().setMethodDetails(mockName, methodName);
             }
 
-            bool isOfMethod(MethodInfo &method) {
+            bool isOfMethod(MethodInfo &method) override {
                 return getRecordedMethodBody().isOfMethod(method);
             }
 
-            ActualInvocationsSource &getInvolvedMock() {
+            ActualInvocationsSource &getInvolvedMock() override {
                 return _mock;
             }
 
-            std::string getMethodName() {
+            std::string getMethodName() override {
                 return getRecordedMethodBody().getMethod().name();
             }
 
@@ -218,7 +218,7 @@ namespace fakeit {
         class UniqueMethodMockingContextImpl : public MethodMockingContextImpl<R, arglist...> {
         protected:
 
-            virtual RecordedMethodBody<R, arglist...> &getRecordedMethodBody() override {
+            RecordedMethodBody<R, arglist...> &getRecordedMethodBody() override {
                 return MethodMockingContextBase<R, arglist...>::_mock.template stubMethodIfNotStubbed<id>(
                         MethodMockingContextBase<R, arglist...>::_mock._proxy,
                         MethodMockingContextImpl<R, arglist...>::_vMethod);
@@ -235,7 +235,7 @@ namespace fakeit {
 
         protected:
 
-            virtual RecordedMethodBody<void> &getRecordedMethodBody() override {
+            RecordedMethodBody<void> &getRecordedMethodBody() override {
                 return MethodMockingContextBase<void>::_mock.stubDtorIfNotStubbed(
                         MethodMockingContextBase<void>::_mock._proxy);
             }

--- a/include/fakeit/RecordedMethodBody.hpp
+++ b/include/fakeit/RecordedMethodBody.hpp
@@ -37,7 +37,7 @@ namespace fakeit {
                     _matcher{matcher}, _invocationHandler{invocationHandler} {
             }
 
-            virtual R handleMethodInvocation(ArgumentsTuple<arglist...> & args) override
+            R handleMethodInvocation(ArgumentsTuple<arglist...> & args) override
             {
                 Destructible &destructable = *_invocationHandler;
                 ActualInvocationHandler<R, arglist...> &invocationHandler = dynamic_cast<ActualInvocationHandler<R, arglist...> &>(destructable);
@@ -95,7 +95,7 @@ namespace fakeit {
         RecordedMethodBody(FakeitContext &fakeit, std::string name) :
                 _fakeit(fakeit), _method{MethodInfo::nextMethodOrdinal(), name} { }
 
-        virtual ~RecordedMethodBody() FAKEIT_NO_THROWS {
+        ~RecordedMethodBody() FAKEIT_NO_THROWS override {
         }
 
         MethodInfo &getMethod() {

--- a/include/fakeit/Sequence.hpp
+++ b/include/fakeit/Sequence.hpp
@@ -57,7 +57,7 @@ namespace fakeit {
 
     public:
 
-        virtual ~ConcatenatedSequence() {
+        ~ConcatenatedSequence() override {
         }
 
         unsigned int size() const override {
@@ -77,7 +77,7 @@ namespace fakeit {
             s2.getExpectedSequence(into);
         }
 
-        virtual void getInvolvedMocks(std::vector<ActualInvocationsSource *> &into) const override {
+        void getInvolvedMocks(std::vector<ActualInvocationsSource *> &into) const override {
             s1.getInvolvedMocks(into);
             s2.getInvolvedMocks(into);
         }
@@ -97,7 +97,7 @@ namespace fakeit {
 
     public:
 
-        ~RepeatedSequence() {
+        ~RepeatedSequence() override {
         }
 
         unsigned int size() const override {

--- a/include/fakeit/WhenFunctor.hpp
+++ b/include/fakeit/WhenFunctor.hpp
@@ -53,7 +53,7 @@ namespace fakeit {
 
             friend class WhenFunctor;
 
-            virtual ~MethodProgress() override = default;
+            ~MethodProgress() override = default;
 
             MethodProgress(const MethodProgress &other) :
                     _progress(other._progress), _context(other._context) {

--- a/include/fakeit/invocation_matchers.hpp
+++ b/include/fakeit/invocation_matchers.hpp
@@ -34,13 +34,13 @@ namespace fakeit {
                 : _matchers(args) {
         }
 
-        virtual bool matches(ActualInvocation<arglist...> &invocation) override {
+        bool matches(ActualInvocation<arglist...> &invocation) override {
             if (invocation.getActualMatcher() == this)
                 return true;
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const override {
+        std::string format() const override {
             std::ostringstream out;
             out << "(";
             for (unsigned int i = 0; i < _matchers.size(); i++) {
@@ -124,13 +124,13 @@ namespace fakeit {
                 : matcher{match} {
         }
 
-        virtual bool matches(ActualInvocation<arglist...> &invocation) override {
+        bool matches(ActualInvocation<arglist...> &invocation) override {
             if (invocation.getActualMatcher() == this)
                 return true;
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const override {
+        std::string format() const override {
             return {"( user defined matcher )"};
         }
 
@@ -150,11 +150,11 @@ namespace fakeit {
         DefaultInvocationMatcher() {
         }
 
-        virtual bool matches(ActualInvocation<arglist...> &invocation) override {
+        bool matches(ActualInvocation<arglist...> &invocation) override {
             return matches(invocation.getActualArguments());
         }
 
-        virtual std::string format() const override {
+        std::string format() const override {
             return {"( Any arguments )"};
         }
 

--- a/tests/custom_event_formatting_tests.cpp
+++ b/tests/custom_event_formatting_tests.cpp
@@ -29,15 +29,15 @@ struct CustomEventFormatting : tpunit::TestFixture {
 
 	class CustomEventFormatter : public EventFormatter {
 
-		virtual std::string format(const fakeit::UnexpectedMethodCallEvent&) {
+		std::string format(const fakeit::UnexpectedMethodCallEvent&) override {
 			return{ "UnexpectedMethodCallEvent" };
 		}
 
-		virtual std::string format(const fakeit::SequenceVerificationEvent&) {
+		std::string format(const fakeit::SequenceVerificationEvent&) override {
 			return{ "SequenceVerificationEvent" };
 		}
 
-		virtual std::string format(const fakeit::NoMoreInvocationsVerificationEvent&) {
+		std::string format(const fakeit::NoMoreInvocationsVerificationEvent&) override {
 			return{ "NoMoreInvocationsVerificationEvent" };
 		}
 

--- a/tests/custom_testing_framework_tests.cpp
+++ b/tests/custom_testing_framework_tests.cpp
@@ -45,28 +45,28 @@ struct CustomTestingFramework: tpunit::TestFixture {
 			std::string _msg;
 		};
 
-		virtual void handle(const UnexpectedMethodCallEvent&) {
+		void handle(const UnexpectedMethodCallEvent&) override {
 			throw AssertionException("UnexpectedMethodCallEvent");
 		}
 
-		virtual void handle(const SequenceVerificationEvent&) {
+		void handle(const SequenceVerificationEvent&) override {
 			throw AssertionException("SequenceVerificationEvent");
 		}
 
-		virtual void handle(const NoMoreInvocationsVerificationEvent&) {
+		void handle(const NoMoreInvocationsVerificationEvent&) override {
 			throw AssertionException("NoMoreInvocationsVerificationEvent");
 		}
 	};
 
 	class NullEventHandler: public fakeit::EventHandler {
 
-		virtual void handle(const UnexpectedMethodCallEvent&) {
+		void handle(const UnexpectedMethodCallEvent&) override {
 		}
 
-		virtual void handle(const SequenceVerificationEvent&) {
+		void handle(const SequenceVerificationEvent&) override {
 		}
 
-		virtual void handle(const NoMoreInvocationsVerificationEvent&) {
+		void handle(const NoMoreInvocationsVerificationEvent&) override {
 		}
 
 		NullEventHandler(const NullEventHandler&) = delete;

--- a/tests/event_notification_tests.cpp
+++ b/tests/event_notification_tests.cpp
@@ -42,28 +42,28 @@ struct EventNotification: tpunit::TestFixture {
 			std::string _msg;
 		};
 
-		virtual void handle(const UnexpectedMethodCallEvent&) {
+		void handle(const UnexpectedMethodCallEvent&) override {
 			throw AssertionException("UnexpectedMethodCallEvent");
 		}
 
-		virtual void handle(const SequenceVerificationEvent&) {
+		void handle(const SequenceVerificationEvent&) override {
 			throw AssertionException("SequenceVerificationEvent");
 		}
 
-		virtual void handle(const NoMoreInvocationsVerificationEvent&) {
+		void handle(const NoMoreInvocationsVerificationEvent&) override {
 			throw AssertionException("NoMoreInvocationsVerificationEvent");
 		}
 	};
 
 	class NullEventHandler: public fakeit::EventHandler {
 
-		virtual void handle(const UnexpectedMethodCallEvent&) {
+		void handle(const UnexpectedMethodCallEvent&) override {
 		}
 
-		virtual void handle(const SequenceVerificationEvent&) {
+		void handle(const SequenceVerificationEvent&) override {
 		}
 
-		virtual void handle(const NoMoreInvocationsVerificationEvent&) {
+		void handle(const NoMoreInvocationsVerificationEvent&) override {
 		}
 
 		NullEventHandler(const NullEventHandler&) = delete;

--- a/tests/move_only_return_tests.cpp
+++ b/tests/move_only_return_tests.cpp
@@ -33,7 +33,7 @@ struct MoveOnlyReturnTests: tpunit::TestFixture {
 		void foo() override {
 		}
 
-		bool operator==(const ConcreteType& other) {
+		bool operator==(const ConcreteType& other) const {
 			return (other.state == this->state);
 		}
 

--- a/tests/move_only_return_tests.cpp
+++ b/tests/move_only_return_tests.cpp
@@ -30,7 +30,7 @@ struct MoveOnlyReturnTests: tpunit::TestFixture {
 		ConcreteType(const ConcreteType&) = delete;
 		ConcreteType(ConcreteType&&) = default;
 
-		virtual void foo() override {
+		void foo() override {
 		}
 
 		bool operator==(const ConcreteType& other) {

--- a/tests/msc_type_info_tests.cpp
+++ b/tests/msc_type_info_tests.cpp
@@ -75,7 +75,7 @@ struct MscTypeInfoTests : tpunit::TestFixture {
 	class Bclass :public Aclass
 	{
 	public:
-		virtual void setA(int tmp)
+		void setA(int tmp) override
 		{
 			a = tmp + 10;
 			std::cout << a << std::endl;

--- a/tests/referece_types_tests.cpp
+++ b/tests/referece_types_tests.cpp
@@ -27,7 +27,7 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 		ConcreteType() :
 				state(10) {
 		}
-		virtual void foo() override {
+		void foo() override {
 		}
 
 		bool operator==(const ConcreteType& other) {

--- a/tests/referece_types_tests.cpp
+++ b/tests/referece_types_tests.cpp
@@ -30,7 +30,7 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 		void foo() override {
 		}
 
-		bool operator==(const ConcreteType& other) {
+		bool operator==(const ConcreteType& other) const {
 			return (other.state == this->state);
 		}
 

--- a/tests/rvalue_arguments_tests.cpp
+++ b/tests/rvalue_arguments_tests.cpp
@@ -21,7 +21,7 @@ struct RValueTypesTests : tpunit::TestFixture {
         void foo() override {
         }
 
-        bool operator==(const ConcreteType& other) {
+        bool operator==(const ConcreteType& other) const {
             return (other.state == this->state);
         }
     };

--- a/tests/rvalue_arguments_tests.cpp
+++ b/tests/rvalue_arguments_tests.cpp
@@ -18,7 +18,7 @@ struct RValueTypesTests : tpunit::TestFixture {
         ConcreteType() :
             state(10) {
         }
-        virtual void foo() override {
+        void foo() override {
         }
 
         bool operator==(const ConcreteType& other) {

--- a/tests/type_info_tests.cpp
+++ b/tests/type_info_tests.cpp
@@ -48,7 +48,7 @@ struct TypeInfoTests : tpunit::TestFixture {
 
 	struct Left : public TopLeft {
 		int left;
-		virtual int l() override = 0;
+		int l() override = 0;
 	};
 
 	struct TopRight {
@@ -58,14 +58,14 @@ struct TypeInfoTests : tpunit::TestFixture {
 
 	struct Right : public TopRight {
 		int right;
-		virtual int r() override = 0;
+		int r() override = 0;
 	};
 
 	struct A : public Left
 	//, public Right
 	{
 		int a;
-		virtual int l() override { return 0; };
+		int l() override { return 0; };
 		//virtual int r() override { return 0; };
 	};
 


### PR DESCRIPTION
- Added missing `const` to `operator==`, which was also creating some compiler error on MSVC with C++20.
- Use only one of `virtual` / `override` / `final` for functions.