### PR TITLE
Fix GCC and Clang warnings on tests

### DIFF
--- a/tests/default_behaviore_tests.cpp
+++ b/tests/default_behaviore_tests.cpp
@@ -210,23 +210,12 @@ struct DefaultBehavioreTests : tpunit::TestFixture {
 	public:
 		virtual ~ISomeInterface3() {
 			int a = 0;
+			(void)a;
 			a++;
 		}
 
 		virtual void methodWithSomeSharedPointer(std::shared_ptr<ISomeInterface3> listener) = 0;
 	};
-
-//	void production_shared_ptr_mock_used_in_invocation() {
-//		std::shared_ptr<ISomeInterface3> pMockInstance;
-//		Mock<ISomeInterface3> mock;
-//		fakeit::Fake(Dtor(mock));
-//		fakeit::Fake(Method(mock, methodWithSomeSharedPointer));
-//
-//		pMockInstance = mock.getShared();
-//		pMockInstance->methodWithSomeSharedPointer(pMockInstance);
-//
-//		pMockInstance = nullptr;
-//	}
 
 	void production_shared_ptr_mock_used_in_invocation() {
 		Mock<ISomeInterface3> mock;

--- a/tests/move_only_return_tests.cpp
+++ b/tests/move_only_return_tests.cpp
@@ -18,10 +18,11 @@ struct MoveOnlyReturnTests: tpunit::TestFixture {
 
 	class AbstractType {
 	public:
+		virtual ~AbstractType() = default;
 		virtual void foo() = 0;
 	};
 
-	class ConcreteType: public AbstractType {
+	class ConcreteType : public AbstractType {
 	public:
 		int state;
 		ConcreteType(int value) :
@@ -84,4 +85,3 @@ struct MoveOnlyReturnTests: tpunit::TestFixture {
 		ASSERT_EQUAL(ConcreteType(10), i.returnMoveOnlyConcreteTypeByRef());
 	}
 } __MoveOnlyReturnTests;
-

--- a/tests/remove_const_volatile_tests.cpp
+++ b/tests/remove_const_volatile_tests.cpp
@@ -82,7 +82,11 @@ public:
 		}
 
 		struct ConstVolatileParameters{
+#if FAKEIT_CPLUSPLUS >= 202002L
+			virtual int func1(const int a, const std::string s) = 0;
+#else
 			virtual int func1(const int a, const volatile std::string s) = 0;
+#endif
 		};
 
 		void TestConstParameters()

--- a/tests/rvalue_arguments_tests.cpp
+++ b/tests/rvalue_arguments_tests.cpp
@@ -28,6 +28,10 @@ struct RValueTypesTests : tpunit::TestFixture {
 
     using CompositeType = std::pair < int, int > ;
 
+#if defined(__GNUG__) && !defined(__clang__) && __GNUC__ >= 13
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Woverloaded-virtual"
+#endif
     struct RValueInterface {
         virtual int intRValueArg(int&&) = 0;
         virtual int compositeRValueArg(CompositeType&&) = 0;
@@ -36,6 +40,9 @@ struct RValueTypesTests : tpunit::TestFixture {
         virtual RValueInterface& operator=(RValueInterface&&) = 0;
         virtual RValueInterface& operator=(const RValueInterface&) = 0;
     };
+#if defined(__GNUG__) && !defined(__clang__) && __GNUC__ >= 13
+#pragma GCC diagnostic pop
+#endif
 
     RValueTypesTests() :
         TestFixture(

--- a/tests/type_info_tests.cpp
+++ b/tests/type_info_tests.cpp
@@ -33,7 +33,8 @@ struct TypeInfoTests : tpunit::TestFixture {
 
 	void mock_should_use_same_typeid_as_mocked_class() {
 		Mock<SomeInterface> mock;
-		ASSERT_EQUAL(typeid(mock.get()), typeid(SomeInterface));
+		auto& mockRef = mock.get();
+		ASSERT_EQUAL(typeid(mockRef), typeid(SomeInterface));
 	}
 
 	struct ConcreteType {

--- a/tests/verification_tests.cpp
+++ b/tests/verification_tests.cpp
@@ -391,8 +391,8 @@ struct BasicVerification: tpunit::TestFixture {
 		{
 			try {
 				const auto a = VerifyNoOtherInvocations(Method(mock,func));
-				if (&a == &a) // use a to avoid unused variable compilation warning.
-					throw std::runtime_error("some exception");
+				(void)a; // use a to avoid unused variable compilation warning.
+				throw std::runtime_error("some exception");
 			} catch (std::runtime_error &) {
 			}
 		}
@@ -405,8 +405,8 @@ struct BasicVerification: tpunit::TestFixture {
 			try {
 				const auto a = Verify(Method(mock,func));
 				//const auto b = Verify(Method(mock, func)).Exactly(1);
-				if (&a == &a) // use a to avoid unused variable compilation warning.
-					throw std::runtime_error("some exception");
+				(void)a; // use a to avoid unused variable compilation warning.
+				throw std::runtime_error("some exception");
 			} catch (std::runtime_error &) {
 			}
 		}


### PR DESCRIPTION
Fix the remaining warnings when compiling the tests with de default options on C++20 and above. Should fix #320.