### PR TITLE
Improve Return for move-only return types.

### DIFF
--- a/tests/move_only_return_tests.cpp
+++ b/tests/move_only_return_tests.cpp
@@ -16,72 +16,113 @@ using namespace fakeit;
 
 struct MoveOnlyReturnTests: tpunit::TestFixture {
 
-	class AbstractType {
-	public:
-		virtual ~AbstractType() = default;
-		virtual void foo() = 0;
-	};
-
-	class ConcreteType : public AbstractType {
+	class MoveOnlyType {
 	public:
 		int state;
-		ConcreteType(int value) :
+		MoveOnlyType(int value) :
 				state(value) {
 		}
-		ConcreteType(const ConcreteType&) = delete;
-		ConcreteType(ConcreteType&&) = default;
+		MoveOnlyType(const MoveOnlyType&) = delete;
+		MoveOnlyType(MoveOnlyType&&) = default;
 
-		void foo() override {
-		}
-
-		bool operator==(const ConcreteType& other) const {
+		bool operator==(const MoveOnlyType& other) const {
 			return (other.state == this->state);
 		}
 
 	};
 
-	struct ReferenceInterface {
+	struct MoveOnlyInterface {
+		virtual std::string returnCopyable() = 0;
 		virtual std::unique_ptr<std::string> returnMoveOnlyUniqueString() = 0;
-		virtual ConcreteType returnMoveOnlyConcreteTypeByRef() = 0;
+		virtual MoveOnlyType returnMoveOnlyType() = 0;
+		virtual std::vector<MoveOnlyType> returnVectorOfMoveOnly() = 0;
 	};
+
+	static std::vector<MoveOnlyType> constructVectorOfMoveOnly(int i) {
+		std::vector<MoveOnlyType> vectorOfMoveOnly;
+		vectorOfMoveOnly.emplace_back(i);
+		return vectorOfMoveOnly;
+	}
 
 	MoveOnlyReturnTests() :
 			tpunit::TestFixture(
 					//
 					TEST(MoveOnlyReturnTests::explicitStubbingReturnValuesFromTemporary),
-					TEST(MoveOnlyReturnTests::explicitStubbingReturnValuesFromMove)
+					TEST(MoveOnlyReturnTests::explicitStubbingReturnValuesFromMove),
+					TEST(MoveOnlyReturnTests::explicitStubbingReturnMultipleValuesMoveAndCopy)
 					//
 							) {
 	}
 
 	void explicitStubbingReturnValuesFromTemporary() {
-		Mock<ReferenceInterface> mock;
+		Mock<MoveOnlyInterface> mock;
 
 		When(Method(mock, returnMoveOnlyUniqueString)).Return(std::unique_ptr<std::string>(new std::string("value")));
-		When(Method(mock, returnMoveOnlyConcreteTypeByRef)).Return(ConcreteType(10));
+		When(Method(mock, returnMoveOnlyType)).Return(MoveOnlyType(10));
+		When(Method(mock, returnVectorOfMoveOnly)).Return(constructVectorOfMoveOnly(5));
 
-		ReferenceInterface & i = mock.get();
+		MoveOnlyInterface & i = mock.get();
 
 		ASSERT_EQUAL("value", *i.returnMoveOnlyUniqueString());
-
-		ASSERT_EQUAL(ConcreteType(10), i.returnMoveOnlyConcreteTypeByRef());
+		ASSERT_EQUAL(MoveOnlyType(10), i.returnMoveOnlyType());
+		ASSERT_EQUAL(constructVectorOfMoveOnly(5), i.returnVectorOfMoveOnly());
 	}
 
 	void explicitStubbingReturnValuesFromMove() {
-		Mock<ReferenceInterface> mock;
+		Mock<MoveOnlyInterface> mock;
 
-		ConcreteType c(10);
-		std::unique_ptr<std::string> string(new std::string("value"));
+		std::string str{"copyable"};
+		std::unique_ptr<std::string> strPtr(new std::string("value"));
+		MoveOnlyType moveOnly(10);
+		std::vector<MoveOnlyType> vectorOfMoveOnly = constructVectorOfMoveOnly(5);
 
-		When(Method(mock, returnMoveOnlyUniqueString)).Return(std::move(string));
-		When(Method(mock, returnMoveOnlyConcreteTypeByRef)).Return(std::move(c));
+		When(Method(mock, returnCopyable)).Return(std::move(str));
+		When(Method(mock, returnMoveOnlyUniqueString)).Return(std::move(strPtr));
+		When(Method(mock, returnMoveOnlyType)).Return(std::move(moveOnly));
+		When(Method(mock, returnVectorOfMoveOnly)).Return(std::move(vectorOfMoveOnly));
 
-		ASSERT_FALSE(string); // check move did happen
+		// check move did happen
+		ASSERT_TRUE(str.empty());
+		ASSERT_EQUAL(strPtr, nullptr);
+		ASSERT_TRUE(vectorOfMoveOnly.empty());
 
-		ReferenceInterface& i = mock.get();
+		MoveOnlyInterface& i = mock.get();
 
+		ASSERT_EQUAL(std::string("copyable"), i.returnCopyable());
 		ASSERT_EQUAL(std::string("value"), *i.returnMoveOnlyUniqueString());
+		ASSERT_EQUAL(MoveOnlyType(10), i.returnMoveOnlyType());
+		ASSERT_EQUAL(constructVectorOfMoveOnly(5), i.returnVectorOfMoveOnly());
+	}
 
-		ASSERT_EQUAL(ConcreteType(10), i.returnMoveOnlyConcreteTypeByRef());
+	void explicitStubbingReturnMultipleValuesMoveAndCopy() {
+		Mock<MoveOnlyInterface> mock;
+
+		std::string copiedStr{"copied"};
+		std::string movedStr{"moved"};
+		std::unique_ptr<std::string> strPtr(new std::string("strPtrMove"));
+		MoveOnlyType moveOnly(100);
+		std::vector<MoveOnlyType> vectorOfMoveOnly = constructVectorOfMoveOnly(50);
+
+		When(Method(mock, returnCopyable)).Return(copiedStr, std::move(movedStr));
+		When(Method(mock, returnMoveOnlyUniqueString)).Return(std::unique_ptr<std::string>(new std::string("strPtrRval")), std::move(strPtr));
+		When(Method(mock, returnMoveOnlyType)).Return(MoveOnlyType(10), std::move(moveOnly));
+		When(Method(mock, returnVectorOfMoveOnly)).Return(constructVectorOfMoveOnly(5), std::move(vectorOfMoveOnly));
+
+		ASSERT_EQUAL(copiedStr, "copied"); // check move did NOT happen
+		// check move did happen
+		ASSERT_TRUE(movedStr.empty());
+		ASSERT_EQUAL(strPtr, nullptr);
+		ASSERT_TRUE(vectorOfMoveOnly.empty());
+
+		MoveOnlyInterface& i = mock.get();
+
+		ASSERT_EQUAL(std::string("copied"), i.returnCopyable());
+		ASSERT_EQUAL(std::string("moved"), i.returnCopyable());
+		ASSERT_EQUAL(std::string("strPtrRval"), *i.returnMoveOnlyUniqueString());
+		ASSERT_EQUAL(std::string("strPtrMove"), *i.returnMoveOnlyUniqueString());
+		ASSERT_EQUAL(MoveOnlyType(10), i.returnMoveOnlyType());
+		ASSERT_EQUAL(MoveOnlyType(100), i.returnMoveOnlyType());
+		ASSERT_EQUAL(constructVectorOfMoveOnly(5), i.returnVectorOfMoveOnly());
+		ASSERT_EQUAL(constructVectorOfMoveOnly(50), i.returnVectorOfMoveOnly());
 	}
 } __MoveOnlyReturnTests;

--- a/tests/stubbing_tests.cpp
+++ b/tests/stubbing_tests.cpp
@@ -412,7 +412,8 @@ struct BasicStubbing : tpunit::TestFixture {
     void stub_a_method_with_mutable_lambda_delegate_always() {
         Mock<SomeInterface> mock;
 
-        When(Method(mock, funcNoArgs)).AlwaysDo([mutableVar = 0]() mutable {
+        int mutableVar = 0;
+        When(Method(mock, funcNoArgs)).AlwaysDo([mutableVar]() mutable {
             return ++mutableVar;
         });
 


### PR DESCRIPTION
Now the object passed to `Return(o)` is always move-returned if it is passed by rvalue reference, even if it can by copied. The goal is that if the user pass it by `std::move` they probably don't want it to be copied (maybe it can increase a counter somewhere and they don't want it to) and it will also fix issues with types where you can't properly detect if they're copyable or not like `std::vector`.

Tests should be added to ensure this behavior (object is not copied even if it has a copy constructor).

@malcolmdavey Do you think this behavior is OK or do you see an issue with it ?

This is only supported by the `Return` function that takes a single object, it should be supported by `Return(o1, o2, o3)`.

A very strange thing happened while implementing that feature, it seems the `template <typename U = T>` trick doesn't work well with `std::is_reference`: https://godbolt.org/z/hjfKaq1dW

The compiler complains that `func(T&& t)` conflicts with `func(const T& t)`. It's true that they conflict, because `T = int&` so once we replace T we get something like `func(T & && t)` and `func(T & const & t)` which collapse to `func(T & t)` and `func(T & t)`. The issue is that `func(T&& t)` should be disabled by SFINAE because `T` is a reference, so it shouldn't cause an error, and it's what happen when using `std::is_copy_constructible`, so why doesn't it work with `std::is_reference` ?

Because this trick doesn't work I used the "inherit partially specialized class" method instead.

Should fix #327.