### PR TITLE
Allow mocks to be moved.

### DIFF
--- a/include/fakeit/Mock.hpp
+++ b/include/fakeit/Mock.hpp
@@ -36,8 +36,6 @@ namespace fakeit {
     class Mock : public ActualInvocationsSource {
         MockImpl<C, baseclasses...> impl;
     public:
-        ~Mock() override = default;
-
         static_assert(std::is_polymorphic<C>::value, "Can only mock a polymorphic type");
 
         Mock() : impl(Fakeit) {

--- a/include/fakeit/MockImpl.hpp
+++ b/include/fakeit/MockImpl.hpp
@@ -33,9 +33,21 @@ namespace fakeit {
 
         MockImpl(FakeitContext &fakeit)
                 : MockImpl<C, baseclasses...>(fakeit, *(createFakeInstance()), false){
-            FakeObject<C, baseclasses...> *fake = asFakeObject(_instanceOwner.get());
-            fake->getVirtualTable().setCookie(1, this);
+            _instanceOwner.get()->getVirtualTable().setCookie(1, this);
         }
+
+        MockImpl(const MockImpl&) = delete;
+        MockImpl(MockImpl&& other) FAKEIT_NO_THROWS
+            : _instanceOwner(std::move(other._instanceOwner))
+            , _proxy(std::move(other._proxy))
+            , _fakeit(other._fakeit) {
+            if (isOwner()) {
+                _instanceOwner.get()->getVirtualTable().setCookie(1, this);
+            }
+        }
+
+        MockImpl& operator=(const MockImpl&) = delete;
+        MockImpl& operator=(MockImpl&&) = delete;
 
         ~MockImpl() FAKEIT_NO_THROWS override {
             _proxy.detach();

--- a/include/mockutils/FakeObject.hpp
+++ b/include/mockutils/FakeObject.hpp
@@ -58,11 +58,6 @@ namespace fakeit
             this->initializeDataMembersArea();
         }
 
-        ~FakeObject()
-        {
-            this->vtable.dispose();
-        }
-
         void setMethod(unsigned int index, void* method)
         {
             this->vtable.setMethod(index, method);
@@ -73,9 +68,9 @@ namespace fakeit
             return this->vtable;
         }
 
-        void setVirtualTable(VirtualTable<C, BaseClasses...>& t)
+        void swapVirtualTable(VirtualTable<C, BaseClasses...>& t)
         {
-            this->vtable = t;
+            std::swap(this->vtable, t);
         }
 
         void setDtor(void* dtor)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(FakeIt_tests
     gcc_type_info_tests.cpp
     miscellaneous_tests.cpp
     move_only_return_tests.cpp
+    moving_mocks_around.cpp
     msc_stubbing_multiple_values_tests.cpp
     msc_type_info_tests.cpp
     overloadded_methods_tests.cpp

--- a/tests/moving_mocks_around.cpp
+++ b/tests/moving_mocks_around.cpp
@@ -1,0 +1,101 @@
+/*
+ * Copyright (c) 2014 Eran Pe'er.
+ *
+ * This program is made available under the terms of the MIT License.
+ *
+ * Created on Mar 10, 2014
+ */
+
+#include "tpunit++.hpp"
+#include "fakeit.hpp"
+
+using namespace fakeit;
+
+struct MovingMocksAround : tpunit::TestFixture
+{
+
+    MovingMocksAround() :
+        TestFixture(
+            TEST(MovingMocksAround::move_mock),
+            TEST(MovingMocksAround::move_mock_then_delete),
+            TEST(MovingMocksAround::create_mock_from_function),
+            TEST(MovingMocksAround::create_multiple_mocks_from_function)
+        )
+    {
+    }
+
+    class Interface
+    {
+    public:
+        virtual std::string function(std::string) = 0;
+        virtual ~Interface() = default;
+    };
+
+    Mock<Interface> createMock(const std::string& str)
+    {
+        Mock<Interface> mock;
+        When(Method(mock, function)).AlwaysReturn(str);
+        return mock;
+    }
+
+    void move_mock()
+    {
+        const std::string paramString = "long param string to not be in SSO ------------------------------------------";
+        const std::string returnedString = "long returned string to not be in SSO ------------------------------------";
+
+        Mock<Interface> mock;
+        When(Method(mock, function)).AlwaysReturn(returnedString);
+
+        Mock<Interface> mockMove = std::move(mock);
+
+        EXPECT_EQUAL(mockMove.get().function(paramString), returnedString);
+
+        Verify(Method(mockMove, function).Using(paramString)).Exactly(1);
+    }
+
+    void move_mock_then_delete()
+    {
+        const std::string paramString = "long param string to not be in SSO ------------------------------------------";
+        const std::string returnedString = "long returned string to not be in SSO ------------------------------------";
+
+        Mock<Interface> *mock = new Mock<Interface>;
+        When(Method(*mock, function)).AlwaysReturn(returnedString);
+
+        Mock<Interface> mockMove = std::move(*mock);
+        delete mock;
+
+        EXPECT_EQUAL(mockMove.get().function(paramString), returnedString);
+
+        Verify(Method(mockMove, function).Using(paramString)).Exactly(1);
+    }
+
+    void create_mock_from_function()
+    {
+        const std::string paramString = "long param string to not be in SSO ------------------------------------------";
+        const std::string returnedString = "long returned string to not be in SSO ------------------------------------";
+
+        Mock<Interface> mock = createMock(returnedString);
+
+        EXPECT_EQUAL(mock.get().function(paramString), returnedString);
+
+        Verify(Method(mock, function).Using(paramString)).Exactly(1);
+    }
+
+    void create_multiple_mocks_from_function()
+    {
+        const std::string paramString1 = "long param 1 string to not be in SSO ---------------------------------------";
+        const std::string returnedString1 = "long returned 1 string to not be in SSO ---------------------------------";
+        const std::string paramString2 = "long param 2 string to not be in SSO ---------------------------------------";
+        const std::string returnedString2 = "long returned 2 string to not be in SSO ---------------------------------";
+
+        Mock<Interface> mock1 = createMock(returnedString1);
+        Mock<Interface> mock2 = createMock(returnedString2);
+
+        EXPECT_EQUAL(mock1.get().function(paramString1), returnedString1);
+        EXPECT_EQUAL(mock2.get().function(paramString2), returnedString2);
+
+        Verify(Method(mock1, function).Using(paramString1)).Exactly(1);
+        Verify(Method(mock2, function).Using(paramString2)).Exactly(1);
+    }
+
+} __MovingMocksAround;


### PR DESCRIPTION
Make mocks move-constructible, so they can be constructed from external functions. They could technically be move-assignable as well but I don't think it would be useful so I haven't done it.

They cannot be copy-constructible because the mocks can contain move-only objects (if a function returning a move-only object is mocked with `Return(MoveOnly{})` then the mock will contain the move-only object that should be returned when that function is called), making them move-only as well.

This should fix #283 and #97.