### PR TITLE
Add 64 bits builds for MSVC in the CI.

### DIFF
--- a/.github/workflows/ci_windows_msvc.yml
+++ b/.github/workflows/ci_windows_msvc.yml
@@ -24,11 +24,26 @@ jobs:
             architecture: "Win32"
           }
           - {
+            name: "Windows 2019 MSVC 2019 x64",
+            os: windows-2019,
+            build_type: Debug,
+            generator: "Visual Studio 16 2019",
+            architecture: "x64"
+          }
+          - {
             name: "Windows 2022 MSVC 2022 Win32 C++11",
             os: windows-2022,
             build_type: Debug,
             generator: "Visual Studio 17 2022",
             architecture: "Win32",
+            cxx_standard: 11
+          }
+          - {
+            name: "Windows 2022 MSVC 2022 x64 C++11",
+            os: windows-2022,
+            build_type: Debug,
+            generator: "Visual Studio 17 2022",
+            architecture: "x64",
             cxx_standard: 11
           }
           - {
@@ -40,6 +55,14 @@ jobs:
             cxx_standard: 14
           }
           - {
+            name: "Windows 2022 MSVC 2022 x64 C++14",
+            os: windows-2022,
+            build_type: Debug,
+            generator: "Visual Studio 17 2022",
+            architecture: "x64",
+            cxx_standard: 14
+          }
+          - {
             name: "Windows 2022 MSVC 2022 Win32 C++17",
             os: windows-2022,
             build_type: Debug,
@@ -48,11 +71,27 @@ jobs:
             cxx_standard: 17
           }
           - {
+            name: "Windows 2022 MSVC 2022 x64 C++17",
+            os: windows-2022,
+            build_type: Debug,
+            generator: "Visual Studio 17 2022",
+            architecture: "x64",
+            cxx_standard: 17
+          }
+          - {
             name: "Windows 2022 MSVC 2022 Win32 C++20",
             os: windows-2022,
             build_type: Debug,
             generator: "Visual Studio 17 2022",
             architecture: "Win32",
+            cxx_standard: 20
+          }
+          - {
+            name: "Windows 2022 MSVC 2022 x64 C++20",
+            os: windows-2022,
+            build_type: Debug,
+            generator: "Visual Studio 17 2022",
+            architecture: "x64",
             cxx_standard: 20
           }
     steps:

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,11 @@ if(CMAKE_CXX_COMPILER_ID STREQUAL "GNU" OR CMAKE_CXX_COMPILER_ID MATCHES "^(Appl
     target_compile_options(FakeIt_tests PRIVATE -Wall -Wextra -Wno-ignored-qualifiers -O0 -g3)
 elseif(MSVC)
     target_compile_options(FakeIt_tests PRIVATE /W3 /sdl /Od)
+
+    if("${CMAKE_GENERATOR_PLATFORM}" STREQUAL "x64")
+        target_compile_definitions(FakeIt_tests PRIVATE FAKEIT_DISABLE_RTTI_DEPENDENT_TESTS)
+        message(STATUS "MSVC 64 bits detected: disabling RTTI-dependent tests as it isn't supported for this configuration.")
+    endif()
 endif()
 
 if(OVERRIDE_CXX_STANDARD_FOR_TESTS)

--- a/tests/type_info_tests.cpp
+++ b/tests/type_info_tests.cpp
@@ -16,14 +16,17 @@ using namespace fakeit;
 struct TypeInfoTests : tpunit::TestFixture {
 
 	TypeInfoTests() :
-	tpunit::TestFixture(
-	//
-	TEST(TypeInfoTests::mock_should_use_same_typeid_as_mocked_class), //
-	TEST(TypeInfoTests::simple_inheritance_upcast), //
-	TEST(TypeInfoTests::dynamic_cast_to_same_type__with_concrete_type),
-	TEST(TypeInfoTests::dynamic_cast_to_same_type__with_abstract_type),
-	TEST(TypeInfoTests::simple_inheritance_dynamic_down_cast) //
-	)  //
+		tpunit::TestFixture(
+#ifndef FAKEIT_DISABLE_RTTI_DEPENDENT_TESTS
+			TEST(TypeInfoTests::mock_should_use_same_typeid_as_mocked_class),
+#endif
+			TEST(TypeInfoTests::simple_inheritance_upcast),
+#ifndef FAKEIT_DISABLE_RTTI_DEPENDENT_TESTS
+			TEST(TypeInfoTests::simple_inheritance_dynamic_down_cast),
+#endif
+			TEST(TypeInfoTests::dynamic_cast_to_same_type__with_concrete_type),
+			TEST(TypeInfoTests::dynamic_cast_to_same_type__with_abstract_type)
+		)
 	{
 	}
 


### PR DESCRIPTION
Disable RTTI-dependent tests as RTTI isn't properly supported on 64 bits MSCV in fakeit for now, but it's not a reason to not run the other tests.

Will fix partially #269.