### PR TITLE
Fix lot of stuffs with .*Return*.

### DIFF
--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -75,7 +75,7 @@ namespace fakeit {
             // can be removed once that deprecated version is removed.
             template <typename U = R, typename std::enable_if<std::is_reference<U>::value, bool>::type = true>
             MethodStubbingProgress<R, arglist...>& Return(fk_remove_cvref_t<R>&& r) {
-                static_assert(sizeof(U) != sizeof(U), "Return() cannot take an rvalue references for functions returning a reference because it would make it dangling, use ReturnCapture() instead.");
+                static_assert(sizeof(U) != sizeof(U), "Return() cannot take an rvalue references for functions returning a reference because it would make it dangling, use ReturnValCapt() instead.");
                 return Return(r); // Only written to silence warning about not returning from a non-void function, but will never be executed.
             }
 
@@ -87,11 +87,11 @@ namespace fakeit {
             // can be removed once that deprecated version is removed.
             template <typename U = R, typename std::enable_if<std::is_reference<U>::value, bool>::type = true>
             void AlwaysReturn(fk_remove_cvref_t<R>&&) {
-                static_assert(sizeof(U) != sizeof(U), "AlwaysReturn() cannot take an rvalue references for functions returning a reference because it would make it dangling, use AlwaysReturnCapture() instead.");
+                static_assert(sizeof(U) != sizeof(U), "AlwaysReturn() cannot take an rvalue references for functions returning a reference because it would make it dangling, use AlwaysReturnValCapt() instead.");
             }
 
             template<typename T>
-            MethodStubbingProgress<R, arglist...>& ReturnCapture(T&& r) {
+            MethodStubbingProgress<R, arglist...>& ReturnValCapt(T&& r) {
                 // If a ref to T can be cast to a ref to R, then store T.
                 // Otherwise, create an object R constructed from the received T and store it.
                 using StoredType = typename std::conditional<
@@ -105,7 +105,7 @@ namespace fakeit {
             }
 
             template<typename T>
-            void AlwaysReturnCapture(T&& r) {
+            void AlwaysReturnValCapt(T&& r) {
                 // If a ref to T can be cast to a ref to R, then store T.
                 // Otherwise, create an object R constructed from the received T and store it.
                 using StoredType = typename std::conditional<
@@ -140,15 +140,15 @@ namespace fakeit {
                 return AlwaysDo([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
             }
 
-            MethodStubbingProgress<R, arglist...>& ReturnCapture(const R& r) {
+            MethodStubbingProgress<R, arglist...>& ReturnValCapt(const R& r) {
                 return Return(r);
             }
 
-            MethodStubbingProgress<R, arglist...>& ReturnCapture(R&& r) {
+            MethodStubbingProgress<R, arglist...>& ReturnValCapt(R&& r) {
                 return Return(std::move(r));
             }
 
-            void AlwaysReturnCapture(const R &r) {
+            void AlwaysReturnValCapt(const R &r) {
                 return AlwaysReturn(r);
             }
         };
@@ -171,19 +171,19 @@ namespace fakeit {
         using helper::BasicReturnImplHelper<R, arglist...>::AlwaysReturn;
 
         // DEPRECATED: This should ideally be removed, it allows writing .Return<std::string>("ok") when a function
-        // returns "const std::string&" (for example) to have the same behavior has .ReturnCapture("ok"). But it is prone
-        // to errors (because you have to specify the type). .ReturnCapture("ok") is superior and should be used instead.
+        // returns "const std::string&" (for example) to have the same behavior has .ReturnValCapt("ok"). But it is prone
+        // to errors (because you have to specify the type). .ReturnValCapt("ok") is superior and should be used instead.
         template<typename TypeUsedToForceCapture, typename RealType, typename std::enable_if<!std::is_reference<TypeUsedToForceCapture>::value, bool>::type = true>
         MethodStubbingProgress<R, arglist...>& Return(RealType&& ret) {
-            return this->ReturnCapture(TypeUsedToForceCapture(std::forward<RealType>(ret)));
+            return this->ReturnValCapt(TypeUsedToForceCapture(std::forward<RealType>(ret)));
         }
 
         // DEPRECATED: This should ideally be removed, it allows writing .AlwaysReturn<std::string>("ok") when a function
-        // returns "const std::string&" (for example) to have the same behavior has .AlwaysReturnCapture("ok"). But it is prone
-        // to errors (because you have to specify the type). .AlwaysReturnCapture("ok") is superior and should be used instead.
+        // returns "const std::string&" (for example) to have the same behavior has .AlwaysReturnValCapt("ok"). But it is prone
+        // to errors (because you have to specify the type). .AlwaysReturnValCapt("ok") is superior and should be used instead.
         template<typename TypeUsedToForceCapture, typename RealType, typename std::enable_if<!std::is_reference<TypeUsedToForceCapture>::value, bool>::type = true>
         void AlwaysReturn(RealType&& ret) {
-            return this->AlwaysReturnCapture(TypeUsedToForceCapture(std::forward<RealType>(ret)));
+            return this->AlwaysReturnValCapt(TypeUsedToForceCapture(std::forward<RealType>(ret)));
         }
 
         MethodStubbingProgress<R, arglist...> &

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -71,7 +71,9 @@ namespace fakeit {
                 return Do([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
             }
 
-            template <typename U = R>
+            // The std::enable_if is only there to disambiguate with the deprecated version of .Return<type>(val), and
+            // can be removed once that deprecated version is removed.
+            template <typename U = R, typename std::enable_if<std::is_reference<U>::value, bool>::type = true>
             MethodStubbingProgress<R, arglist...>& Return(fk_remove_cvref_t<R>&& r) {
                 static_assert(sizeof(U) != sizeof(U), "Return() cannot take an rvalue references for functions returning a reference because it would make it dangling, use ReturnCapture() instead.");
                 return Return(r); // Only written to silence warning about not returning from a non-void function, but will never be executed.
@@ -88,9 +90,13 @@ namespace fakeit {
 
             template<typename T>
             MethodStubbingProgress<R, arglist...>& ReturnCapture(T&& r) {
-                static_assert(std::is_constructible<fk_remove_cvref_t<R>&, fk_remove_cvref_t<T>&>::value,
-                        "The type captured by ReturnCapture() (named T) must be compatible with the return type of the function (named R), i.e. T t{...}; R& r = t; must compile without creating temporaries.");
-                auto store = std::make_shared<fk_remove_cvref_t<T>>(std::forward<T>(r));
+                // If a ref to T can be cast to a ref to R, then store T.
+                // Otherwise, create an object R constructed from the received T and store it.
+                using StoredType = typename std::conditional<
+                    std::is_constructible<fk_remove_cvref_t<R>&, fk_remove_cvref_t<T>&>::value,
+                    fk_remove_cvref_t<T>,
+                    fk_remove_cvref_t<R>>::type;
+                auto store = std::make_shared<StoredType>(std::forward<T>(r));
                 return Do([store](const typename fakeit::test_arg<arglist>::type...) mutable -> R {
                     return std::forward<R>(*store);
                 });
@@ -98,9 +104,13 @@ namespace fakeit {
 
             template<typename T>
             void AlwaysReturnCapture(T&& r) {
-                static_assert(std::is_constructible<fk_remove_cvref_t<R>&, fk_remove_cvref_t<T>&>::value,
-                        "The type captured by AlwaysReturnCapture() (named T) must be compatible with the return type of the function (named R), i.e. T t{...}; R& r = t; must compile without creating temporaries.");
-                auto store = std::make_shared<fk_remove_cvref_t<T>>(std::forward<T>(r));
+                // If a ref to T can be cast to a ref to R, then store T.
+                // Otherwise, create an object R constructed from the received T and store it.
+                using StoredType = typename std::conditional<
+                    std::is_constructible<fk_remove_cvref_t<R>&, fk_remove_cvref_t<T>&>::value,
+                    fk_remove_cvref_t<T>,
+                    fk_remove_cvref_t<R>>::type;
+                auto store = std::make_shared<StoredType>(std::forward<T>(r));
                 return AlwaysDo([store](const typename fakeit::test_arg<arglist>::type...) mutable -> R {
                     return std::forward<R>(*store);
                 });
@@ -127,6 +137,18 @@ namespace fakeit {
             void AlwaysReturn(const R &r) {
                 return AlwaysDo([r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
             }
+
+            MethodStubbingProgress<R, arglist...>& ReturnCapture(const R& r) {
+                return Return(r);
+            }
+
+            MethodStubbingProgress<R, arglist...>& ReturnCapture(R&& r) {
+                return Return(std::move(r));
+            }
+
+            void AlwaysReturnCapture(const R &r) {
+                return AlwaysReturn(r);
+            }
         };
 
         template<typename R, typename ... arglist>
@@ -145,6 +167,14 @@ namespace fakeit {
         using helper::BasicReturnImplHelper<R, arglist...>::AlwaysDo;
         using helper::BasicReturnImplHelper<R, arglist...>::Return;
         using helper::BasicReturnImplHelper<R, arglist...>::AlwaysReturn;
+
+        // DEPRECATED: This should ideally be removed, it allows writing .Return<std::string>("ok") when a function
+        // returns "const std::string&" (for example) to have the same behavior has .ReturnCapture("ok"). But it is prone
+        // to errors (because you have to specify the type). .ReturnCapture("ok") is superior and should be used instead.
+        template<typename TypeUsedToForceCapture, typename RealType, typename std::enable_if<!std::is_reference<TypeUsedToForceCapture>::value, bool>::type = true>
+        MethodStubbingProgress<R, arglist...>& Return(RealType&& ret) {
+            return this->ReturnCapture(TypeUsedToForceCapture(std::forward<RealType>(ret)));
+        }
 
         MethodStubbingProgress<R, arglist...> &
         Return(const Quantifier<R> &q) {

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -90,7 +90,7 @@ namespace fakeit {
                 static_assert(sizeof(U) != sizeof(U), "AlwaysReturn() cannot take an rvalue references for functions returning a reference because it would make it dangling, use AlwaysReturnValCapt() instead.");
             }
 
-            template<typename T>
+            template<typename T = R>
             MethodStubbingProgress<R, arglist...>& ReturnValCapt(T&& r) {
                 // If a ref to T can be cast to a ref to R, then store T.
                 // Otherwise, create an object R constructed from the received T and store it.
@@ -104,7 +104,7 @@ namespace fakeit {
                 });
             }
 
-            template<typename T>
+            template<typename T = R>
             void AlwaysReturnValCapt(T&& r) {
                 // If a ref to T can be cast to a ref to R, then store T.
                 // Otherwise, create an object R constructed from the received T and store it.

--- a/include/fakeit/StubbingProgress.hpp
+++ b/include/fakeit/StubbingProgress.hpp
@@ -117,6 +117,16 @@ namespace fakeit {
                     return std::forward<R>(*store);
                 });
             }
+
+            template<typename T>
+            MethodStubbingProgress<R, arglist...>& ReturnRefCapt(T&& r) {
+                return Return(std::forward<T>(r));
+            }
+
+            template<typename T>
+            MethodStubbingProgress<R, arglist...>& AlwaysReturnRefCapt(T&& r) {
+                return AlwaysReturn(std::forward<T>(r));
+            }
         };
 
         // If R is not a reference.
@@ -150,6 +160,18 @@ namespace fakeit {
 
             void AlwaysReturnValCapt(const R &r) {
                 return AlwaysReturn(r);
+            }
+
+            template<typename T>
+            MethodStubbingProgress<R, arglist...>& ReturnRefCapt(T&& r) {
+                static_assert(std::is_lvalue_reference<T>::value, "ReturnRefCapt() cannot take an rvalue references because it would make it dangling, use ReturnValCapt() instead.");
+                return Do([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
+            }
+
+            template<typename T>
+            MethodStubbingProgress<R, arglist...>& AlwaysReturnRefCapt(T&& r) {
+                static_assert(std::is_lvalue_reference<T>::value, "AlwaysReturnRefCapt() cannot take an rvalue references because it would make it dangling, use AlwaysReturnValCapt() instead.");
+                return AlwaysDo([&r](const typename fakeit::test_arg<arglist>::type...) -> R { return r; });
             }
         };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(FakeIt_tests
     overloadded_methods_tests.cpp
     referece_types_tests.cpp
     remove_const_volatile_tests.cpp
+    return_template_specialization.cpp
     rvalue_arguments_tests.cpp
     sequence_verification_tests.cpp
     spying_tests.cpp

--- a/tests/referece_types_tests.cpp
+++ b/tests/referece_types_tests.cpp
@@ -240,10 +240,10 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 			ConcreteType concrete{"myConcreteType"};
 
 			// explicit copy here
-			When(Method(mock, returnStringByConstRef)).ReturnCapture(aString);
-			When(Method(mock, returnStringByRValRef)).ReturnCapture(bString);
-			When(Method(mock, returnIntByRef)).ReturnCapture(num);
-			When(Method(mock, returnAbstractTypeByRef)).ReturnCapture(concrete);
+			When(Method(mock, returnStringByConstRef)).ReturnValCapt(aString);
+			When(Method(mock, returnStringByRValRef)).ReturnValCapt(bString);
+			When(Method(mock, returnIntByRef)).ReturnValCapt(num);
+			When(Method(mock, returnAbstractTypeByRef)).ReturnValCapt(concrete);
 
 			// modify now so know whether or not is was copied
 			aString = "modified";
@@ -276,13 +276,13 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 			ConcreteType concrete{"myConcreteType"};
 
 			// explicit move here
-			When(Method(mock, returnStringByConstRef)).ReturnCapture(std::move(aString));
-			When(Method(mock, returnStringByRef)).ReturnCapture(std::move(bString));
-			When(Method(mock, returnStringByRValRef)).ReturnCapture(std::move(cString));
-			When(Method(mock, returnMoveOnlyByConstRef)).ReturnCapture(std::move(aPtrString));
-			When(Method(mock, returnMoveOnlyByRef)).ReturnCapture(std::move(bPtrString));
-			When(Method(mock, returnMoveOnlyByRValRef)).ReturnCapture(std::move(cPtrString));
-			When(Method(mock, returnAbstractTypeByRef)).ReturnCapture(std::move(concrete));
+			When(Method(mock, returnStringByConstRef)).ReturnValCapt(std::move(aString));
+			When(Method(mock, returnStringByRef)).ReturnValCapt(std::move(bString));
+			When(Method(mock, returnStringByRValRef)).ReturnValCapt(std::move(cString));
+			When(Method(mock, returnMoveOnlyByConstRef)).ReturnValCapt(std::move(aPtrString));
+			When(Method(mock, returnMoveOnlyByRef)).ReturnValCapt(std::move(bPtrString));
+			When(Method(mock, returnMoveOnlyByRValRef)).ReturnValCapt(std::move(cPtrString));
+			When(Method(mock, returnAbstractTypeByRef)).ReturnValCapt(std::move(concrete));
 
 			// Verify objects were moved.
 			EXPECT_TRUE(aString.empty());
@@ -311,13 +311,13 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 		Mock<ReferenceInterface> mock;
 
 		{
-			When(Method(mock, returnStringByConstRef)).ReturnCapture(std::string{"aString"});
-			When(Method(mock, returnStringByRef)).ReturnCapture(std::string{"bString"});
-			When(Method(mock, returnStringByRValRef)).ReturnCapture(std::string{"cString"});
-			When(Method(mock, returnMoveOnlyByConstRef)).ReturnCapture(std::unique_ptr<std::string>(new std::string{"aPtrString"}));
-			When(Method(mock, returnMoveOnlyByRef)).ReturnCapture(std::unique_ptr<std::string>(new std::string{"bPtrString"}));
-			When(Method(mock, returnMoveOnlyByRValRef)).ReturnCapture(std::unique_ptr<std::string>(new std::string{"cPtrString"}));
-			When(Method(mock, returnAbstractTypeByRef)).ReturnCapture(ConcreteType{"myConcreteType"});
+			When(Method(mock, returnStringByConstRef)).ReturnValCapt(std::string{"aString"});
+			When(Method(mock, returnStringByRef)).ReturnValCapt(std::string{"bString"});
+			When(Method(mock, returnStringByRValRef)).ReturnValCapt(std::string{"cString"});
+			When(Method(mock, returnMoveOnlyByConstRef)).ReturnValCapt(std::unique_ptr<std::string>(new std::string{"aPtrString"}));
+			When(Method(mock, returnMoveOnlyByRef)).ReturnValCapt(std::unique_ptr<std::string>(new std::string{"bPtrString"}));
+			When(Method(mock, returnMoveOnlyByRValRef)).ReturnValCapt(std::unique_ptr<std::string>(new std::string{"cPtrString"}));
+			When(Method(mock, returnAbstractTypeByRef)).ReturnValCapt(ConcreteType{"myConcreteType"});
 		}
 
 		ReferenceInterface& i = mock.get();
@@ -344,10 +344,10 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 			ConcreteType concrete{"myConcreteType"};
 
 			// explicit copy here
-			When(Method(mock, returnStringByConstRef)).AlwaysReturnCapture(aString);
-			When(Method(mock, returnStringByRValRef)).AlwaysReturnCapture(bString);
-			When(Method(mock, returnIntByRef)).AlwaysReturnCapture(num);
-			When(Method(mock, returnAbstractTypeByRef)).AlwaysReturnCapture(concrete);
+			When(Method(mock, returnStringByConstRef)).AlwaysReturnValCapt(aString);
+			When(Method(mock, returnStringByRValRef)).AlwaysReturnValCapt(bString);
+			When(Method(mock, returnIntByRef)).AlwaysReturnValCapt(num);
+			When(Method(mock, returnAbstractTypeByRef)).AlwaysReturnValCapt(concrete);
 
 			// modify now so know whether or not is was copied
 			aString = "modified";
@@ -395,13 +395,13 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 			ConcreteType concrete{"myConcreteType"};
 
 			// explicit move here
-			When(Method(mock, returnStringByConstRef)).AlwaysReturnCapture(std::move(aString));
-			When(Method(mock, returnStringByRef)).AlwaysReturnCapture(std::move(bString));
-			When(Method(mock, returnStringByRValRef)).AlwaysReturnCapture(std::move(cString));
-			When(Method(mock, returnMoveOnlyByConstRef)).AlwaysReturnCapture(std::move(aPtrString));
-			When(Method(mock, returnMoveOnlyByRef)).AlwaysReturnCapture(std::move(bPtrString));
-			When(Method(mock, returnMoveOnlyByRValRef)).AlwaysReturnCapture(std::move(cPtrString));
-			When(Method(mock, returnAbstractTypeByRef)).AlwaysReturnCapture(std::move(concrete));
+			When(Method(mock, returnStringByConstRef)).AlwaysReturnValCapt(std::move(aString));
+			When(Method(mock, returnStringByRef)).AlwaysReturnValCapt(std::move(bString));
+			When(Method(mock, returnStringByRValRef)).AlwaysReturnValCapt(std::move(cString));
+			When(Method(mock, returnMoveOnlyByConstRef)).AlwaysReturnValCapt(std::move(aPtrString));
+			When(Method(mock, returnMoveOnlyByRef)).AlwaysReturnValCapt(std::move(bPtrString));
+			When(Method(mock, returnMoveOnlyByRValRef)).AlwaysReturnValCapt(std::move(cPtrString));
+			When(Method(mock, returnAbstractTypeByRef)).AlwaysReturnValCapt(std::move(concrete));
 
 			// Verify objects were moved.
 			EXPECT_TRUE(aString.empty());
@@ -453,13 +453,13 @@ struct ReferenceTypesTests: tpunit::TestFixture {
 		Mock<ReferenceInterface> mock;
 
 		{
-			When(Method(mock, returnStringByConstRef)).AlwaysReturnCapture(std::string{"aString"});
-			When(Method(mock, returnStringByRef)).AlwaysReturnCapture(std::string{"bString"});
-			When(Method(mock, returnStringByRValRef)).AlwaysReturnCapture(std::string{"cString"});
-			When(Method(mock, returnMoveOnlyByConstRef)).AlwaysReturnCapture(std::unique_ptr<std::string>(new std::string{"aPtrString"}));
-			When(Method(mock, returnMoveOnlyByRef)).AlwaysReturnCapture(std::unique_ptr<std::string>(new std::string{"bPtrString"}));
-			When(Method(mock, returnMoveOnlyByRValRef)).AlwaysReturnCapture(std::unique_ptr<std::string>(new std::string{"cPtrString"}));
-			When(Method(mock, returnAbstractTypeByRef)).AlwaysReturnCapture(ConcreteType{"myConcreteType"});
+			When(Method(mock, returnStringByConstRef)).AlwaysReturnValCapt(std::string{"aString"});
+			When(Method(mock, returnStringByRef)).AlwaysReturnValCapt(std::string{"bString"});
+			When(Method(mock, returnStringByRValRef)).AlwaysReturnValCapt(std::string{"cString"});
+			When(Method(mock, returnMoveOnlyByConstRef)).AlwaysReturnValCapt(std::unique_ptr<std::string>(new std::string{"aPtrString"}));
+			When(Method(mock, returnMoveOnlyByRef)).AlwaysReturnValCapt(std::unique_ptr<std::string>(new std::string{"bPtrString"}));
+			When(Method(mock, returnMoveOnlyByRValRef)).AlwaysReturnValCapt(std::unique_ptr<std::string>(new std::string{"cPtrString"}));
+			When(Method(mock, returnAbstractTypeByRef)).AlwaysReturnValCapt(ConcreteType{"myConcreteType"});
 		}
 
 		ReferenceInterface& i = mock.get();

--- a/tests/return_template_specialization.cpp
+++ b/tests/return_template_specialization.cpp
@@ -46,7 +46,8 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
             TEST(ReturnTemplateSpecializationTests::always_return_valspecialization_from_other_type_variable),
             TEST(ReturnTemplateSpecializationTests::always_return_refspecialization_from_other_type_variable),
             TEST(ReturnTemplateSpecializationTests::always_return_valcapt_from_other_type_variable),
-            TEST(ReturnTemplateSpecializationTests::always_return_refcapt_from_other_type_variable)
+            TEST(ReturnTemplateSpecializationTests::always_return_refcapt_from_other_type_variable),
+            TEST(ReturnTemplateSpecializationTests::test_implicitly_deduced_type)
         ) {
     }
 
@@ -67,6 +68,10 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         virtual std::string returnVal() = 0;
 
         virtual MoveOnly returnValMo() = 0;
+
+        virtual std::pair<int, int> returnPair() = 0;
+
+        virtual const std::pair<int, int>& returnRefPair() = 0;
     };
 
     void return_default_from_same_type_temp() {
@@ -831,6 +836,28 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
             ASSERT_EQUAL(mock.get().returnVal(), "another different thing");
             Verify(Method(mock, returnVal)).Exactly(2);
         }
+    }
+
+    void test_implicitly_deduced_type() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnPair)).ReturnValCapt({1, 2});
+        ASSERT_EQUAL(mock.get().returnPair(), (std::pair<int, int>{1, 2}));
+        Verify(Method(mock, returnPair)).Once();
+
+        When(Method(mock, returnRefPair)).ReturnValCapt({10, 20});
+        ASSERT_EQUAL(mock.get().returnRefPair(), (std::pair<int, int>{10, 20}));
+        Verify(Method(mock, returnRefPair)).Once();
+
+        When(Method(mock, returnPair)).AlwaysReturnValCapt({3, 4});
+        ASSERT_EQUAL(mock.get().returnPair(), (std::pair<int, int>{3, 4}));
+        ASSERT_EQUAL(mock.get().returnPair(), (std::pair<int, int>{3, 4}));
+        Verify(Method(mock, returnPair)).Exactly(3);
+
+        When(Method(mock, returnRefPair)).AlwaysReturnValCapt({30, 40});
+        ASSERT_EQUAL(mock.get().returnRefPair(), (std::pair<int, int>{30, 40}));
+        ASSERT_EQUAL(mock.get().returnRefPair(), (std::pair<int, int>{30, 40}));
+        Verify(Method(mock, returnRefPair)).Exactly(3);
     }
 
 } __ReturnTemplateSpecializationTests;

--- a/tests/return_template_specialization.cpp
+++ b/tests/return_template_specialization.cpp
@@ -15,13 +15,24 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
 
     ReturnTemplateSpecializationTests()
         : tpunit::TestFixture(
-            TEST(ReturnTemplateSpecializationTests::return_specialization_from_same_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_default_from_same_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_valspecialization_from_same_type_temp),
             TEST(ReturnTemplateSpecializationTests::return_capture_from_same_type_temp),
-            TEST(ReturnTemplateSpecializationTests::return_specialization_from_other_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_default_from_other_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_valspecialization_from_other_type_temp),
             TEST(ReturnTemplateSpecializationTests::return_capture_from_other_type_temp),
             TEST(ReturnTemplateSpecializationTests::return_default_from_variable),
-            TEST(ReturnTemplateSpecializationTests::return_specialization_from_variable),
-            TEST(ReturnTemplateSpecializationTests::return_capture_from_variable)
+            TEST(ReturnTemplateSpecializationTests::return_valspecialization_from_variable),
+            TEST(ReturnTemplateSpecializationTests::return_capture_from_variable),
+            TEST(ReturnTemplateSpecializationTests::always_return_default_from_same_type_temp),
+            TEST(ReturnTemplateSpecializationTests::always_return_valspecialization_from_same_type_temp),
+            TEST(ReturnTemplateSpecializationTests::always_return_capture_from_same_type_temp),
+            TEST(ReturnTemplateSpecializationTests::always_return_default_from_other_type_temp),
+            TEST(ReturnTemplateSpecializationTests::always_return_valspecialization_from_other_type_temp),
+            TEST(ReturnTemplateSpecializationTests::always_return_capture_from_other_type_temp),
+            TEST(ReturnTemplateSpecializationTests::always_return_default_from_variable),
+            TEST(ReturnTemplateSpecializationTests::always_return_valspecialization_from_variable),
+            TEST(ReturnTemplateSpecializationTests::always_return_capture_from_variable)
         ) {
     }
 
@@ -44,7 +55,19 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         virtual MoveOnly returnValMo() = 0;
     };
 
-    void return_specialization_from_same_type_temp() {
+    void return_default_from_same_type_temp() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnVal)).Return(std::string("something"));
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        Verify(Method(mock, returnVal)).Once();
+
+        When(Method(mock, returnValMo)).Return(MoveOnly{5});
+        ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+        Verify(Method(mock, returnValMo)).Once();
+    }
+
+    void return_valspecialization_from_same_type_temp() {
         Mock<SomeStruct> mock;
 
         When(Method(mock, returnRef)).Return<std::string>(std::string("something"));
@@ -84,7 +107,19 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         Verify(Method(mock, returnValMo)).Once();
     }
 
-    void return_specialization_from_other_type_temp() {
+    void return_default_from_other_type_temp() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnVal)).Return("something");
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        Verify(Method(mock, returnVal)).Once();
+
+        When(Method(mock, returnValMo)).Return(5);
+        ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+        Verify(Method(mock, returnValMo)).Once();
+    }
+
+    void return_valspecialization_from_other_type_temp() {
         Mock<SomeStruct> mock;
 
         When(Method(mock, returnRef)).Return<std::string>("something");
@@ -158,7 +193,7 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         }
     }
 
-    void return_specialization_from_variable() {
+    void return_valspecialization_from_variable() {
         Mock<SomeStruct> mock;
 
         {
@@ -223,6 +258,202 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
             mo.i = 10;
             ASSERT_EQUAL(mock.get().returnValMo().i, 5);
             Verify(Method(mock, returnValMo)).Once();
+        }
+    }
+
+    void always_return_default_from_same_type_temp() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnVal)).AlwaysReturn(std::string("something"));
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        Verify(Method(mock, returnVal)).Exactly(2);
+    }
+
+    void always_return_valspecialization_from_same_type_temp() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnRef)).AlwaysReturn<std::string>(std::string("something"));
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        Verify(Method(mock, returnRef)).Exactly(2);
+
+        When(Method(mock, returnRefMo)).AlwaysReturn<MoveOnly>(MoveOnly{5});
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        Verify(Method(mock, returnRefMo)).Exactly(2);
+
+        When(Method(mock, returnVal)).AlwaysReturn<std::string>(std::string("something"));
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        Verify(Method(mock, returnVal)).Exactly(2);
+    }
+
+    void always_return_capture_from_same_type_temp() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnRef)).AlwaysReturnCapture(std::string("something"));
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        Verify(Method(mock, returnRef)).Exactly(2);
+
+        When(Method(mock, returnRefMo)).AlwaysReturnCapture(MoveOnly{5});
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        Verify(Method(mock, returnRefMo)).Exactly(2);
+
+        When(Method(mock, returnVal)).AlwaysReturnCapture(std::string("something"));
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        Verify(Method(mock, returnVal)).Exactly(2);
+    }
+
+    void always_return_default_from_other_type_temp() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnVal)).AlwaysReturn("something");
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        Verify(Method(mock, returnVal)).Exactly(2);
+    }
+
+    void always_return_valspecialization_from_other_type_temp() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnRef)).AlwaysReturn<std::string>("something");
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        Verify(Method(mock, returnRef)).Exactly(2);
+
+        When(Method(mock, returnRefMo)).AlwaysReturn<MoveOnly>(5);
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        Verify(Method(mock, returnRefMo)).Exactly(2);
+
+        When(Method(mock, returnVal)).AlwaysReturn<std::string>("something");
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        Verify(Method(mock, returnVal)).Exactly(2);
+    }
+
+    void always_return_capture_from_other_type_temp() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnRef)).AlwaysReturnCapture("something");
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        Verify(Method(mock, returnRef)).Exactly(2);
+
+        When(Method(mock, returnRefMo)).AlwaysReturnCapture(5);
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        Verify(Method(mock, returnRefMo)).Exactly(2);
+
+        When(Method(mock, returnVal)).AlwaysReturnCapture("something");
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        Verify(Method(mock, returnVal)).Exactly(2);
+    }
+
+    void always_return_default_from_variable() {
+        Mock<SomeStruct> mock;
+
+        {
+            std::string something = "something";
+            MoveOnly mo = 5;
+
+            When(Method(mock, returnRef)).AlwaysReturn(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "a different thing");
+            something = "another different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "another different thing");
+            Verify(Method(mock, returnRef)).Exactly(2);
+
+            When(Method(mock, returnRefMo)).AlwaysReturn(mo);
+            mo.i = 10;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 10);
+            mo.i = 50;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 50);
+            Verify(Method(mock, returnRefMo)).Exactly(2);
+        }
+
+        {
+            std::string something = "something";
+
+            When(Method(mock, returnVal)).AlwaysReturn(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            something = "another different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            Verify(Method(mock, returnVal)).Exactly(2);
+        }
+    }
+
+    void always_return_valspecialization_from_variable() {
+        Mock<SomeStruct> mock;
+
+        {
+            std::string something = "something";
+            MoveOnly mo = 5;
+
+            When(Method(mock, returnRef)).AlwaysReturn<std::string>(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "something");
+            something = "another different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "something");
+            Verify(Method(mock, returnRef)).Exactly(2);
+
+            When(Method(mock, returnRefMo)).AlwaysReturn<MoveOnly>(std::move(mo));
+            mo.i = 10;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+            mo.i = 50;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+            Verify(Method(mock, returnRefMo)).Exactly(2);
+        }
+
+        {
+            std::string something = "something";
+
+            When(Method(mock, returnVal)).AlwaysReturn<std::string>(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            something = "another different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            Verify(Method(mock, returnVal)).Exactly(2);
+        }
+    }
+
+    void always_return_capture_from_variable() {
+        Mock<SomeStruct> mock;
+
+        {
+            std::string something = "something";
+            MoveOnly mo = 5;
+
+            When(Method(mock, returnRef)).AlwaysReturnCapture(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "something");
+            something = "another different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "something");
+            Verify(Method(mock, returnRef)).Exactly(2);
+
+            When(Method(mock, returnRefMo)).AlwaysReturnCapture(std::move(mo));
+            mo.i = 10;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+            mo.i = 50;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+            Verify(Method(mock, returnRefMo)).Exactly(2);
+        }
+
+        {
+            std::string something = "something";
+
+            When(Method(mock, returnVal)).AlwaysReturnCapture(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            something = "another different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            Verify(Method(mock, returnVal)).Exactly(2);
         }
     }
 

--- a/tests/return_template_specialization.cpp
+++ b/tests/return_template_specialization.cpp
@@ -24,9 +24,11 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
             TEST(ReturnTemplateSpecializationTests::return_default_from_same_type_variable),
             TEST(ReturnTemplateSpecializationTests::return_valspecialization_from_same_type_variable),
             TEST(ReturnTemplateSpecializationTests::return_valcapt_from_same_type_variable),
+            TEST(ReturnTemplateSpecializationTests::return_refcapt_from_same_type_variable),
             TEST(ReturnTemplateSpecializationTests::return_default_from_other_type_variable),
             TEST(ReturnTemplateSpecializationTests::return_valspecialization_from_other_type_variable),
             TEST(ReturnTemplateSpecializationTests::return_valcapt_from_other_type_variable),
+            TEST(ReturnTemplateSpecializationTests::return_refcapt_from_other_type_variable),
             TEST(ReturnTemplateSpecializationTests::always_return_default_from_same_type_temp),
             TEST(ReturnTemplateSpecializationTests::always_return_valspecialization_from_same_type_temp),
             TEST(ReturnTemplateSpecializationTests::always_return_valcapt_from_same_type_temp),
@@ -267,6 +269,34 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         }
     }
 
+    void return_refcapt_from_same_type_variable() {
+        Mock<SomeStruct> mock;
+
+        {
+            std::string something = "something";
+            MoveOnly mo = 5;
+
+            When(Method(mock, returnRef)).ReturnRefCapt(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "a different thing");
+            Verify(Method(mock, returnRef)).Once();
+
+            When(Method(mock, returnRefMo)).ReturnRefCapt(mo);
+            mo.i = 10;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 10);
+            Verify(Method(mock, returnRefMo)).Once();
+        }
+
+        {
+            std::string something = "something";
+
+            When(Method(mock, returnVal)).ReturnRefCapt(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "a different thing");
+            Verify(Method(mock, returnVal)).Once();
+        }
+    }
+
     void return_default_from_other_type_variable() {
         Mock<SomeStruct> mock;
 
@@ -350,6 +380,25 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
             When(Method(mock, returnValMo)).ReturnValCapt(num);
             num = 10;
             ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+            Verify(Method(mock, returnValMo)).Once();
+        }
+    }
+
+    void return_refcapt_from_other_type_variable() {
+        Mock<SomeStruct> mock;
+
+        {
+            const char* something = "something";
+            int num = 5;
+
+            When(Method(mock, returnVal)).ReturnRefCapt(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "a different thing");
+            Verify(Method(mock, returnVal)).Once();
+
+            When(Method(mock, returnValMo)).ReturnRefCapt(num);
+            num = 10;
+            ASSERT_EQUAL(mock.get().returnValMo().i, 10);
             Verify(Method(mock, returnValMo)).Once();
         }
     }

--- a/tests/return_template_specialization.cpp
+++ b/tests/return_template_specialization.cpp
@@ -15,13 +15,13 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
 
     ReturnTemplateSpecializationTests()
         : tpunit::TestFixture(
-            TEST(ReturnTemplateSpecializationTests::return_ref_specialization_from_same_type_temp),
-            TEST(ReturnTemplateSpecializationTests::return_ref_capture_from_same_type_temp),
-            TEST(ReturnTemplateSpecializationTests::return_ref_specialization_from_other_type_temp),
-            TEST(ReturnTemplateSpecializationTests::return_ref_capture_from_other_type_temp),
-            TEST(ReturnTemplateSpecializationTests::return_ref_default_from_variable),
-            TEST(ReturnTemplateSpecializationTests::return_ref_specialization_from_variable),
-            TEST(ReturnTemplateSpecializationTests::return_ref_capture_from_variable)
+            TEST(ReturnTemplateSpecializationTests::return_specialization_from_same_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_capture_from_same_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_specialization_from_other_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_capture_from_other_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_default_from_variable),
+            TEST(ReturnTemplateSpecializationTests::return_specialization_from_variable),
+            TEST(ReturnTemplateSpecializationTests::return_capture_from_variable)
         ) {
     }
 
@@ -40,9 +40,11 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         virtual const MoveOnly& returnRefMo() = 0;
 
         virtual std::string returnVal() = 0;
+
+        virtual MoveOnly returnValMo() = 0;
     };
 
-    void return_ref_specialization_from_same_type_temp() {
+    void return_specialization_from_same_type_temp() {
         Mock<SomeStruct> mock;
 
         When(Method(mock, returnRef)).Return<std::string>(std::string("something"));
@@ -52,9 +54,17 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         When(Method(mock, returnRefMo)).Return<MoveOnly>(MoveOnly{5});
         ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
         Verify(Method(mock, returnRefMo)).Once();
+
+        When(Method(mock, returnVal)).Return<std::string>(std::string("something"));
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        Verify(Method(mock, returnVal)).Once();
+
+        When(Method(mock, returnValMo)).Return<MoveOnly>(MoveOnly{5});
+        ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+        Verify(Method(mock, returnValMo)).Once();
     }
 
-    void return_ref_capture_from_same_type_temp() {
+    void return_capture_from_same_type_temp() {
         Mock<SomeStruct> mock;
 
         When(Method(mock, returnRef)).ReturnCapture(std::string("something"));
@@ -64,9 +74,17 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         When(Method(mock, returnRefMo)).ReturnCapture(MoveOnly{5});
         ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
         Verify(Method(mock, returnRefMo)).Once();
+
+        When(Method(mock, returnVal)).ReturnCapture(std::string("something"));
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        Verify(Method(mock, returnVal)).Once();
+
+        When(Method(mock, returnValMo)).ReturnCapture(MoveOnly{5});
+        ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+        Verify(Method(mock, returnValMo)).Once();
     }
 
-    void return_ref_specialization_from_other_type_temp() {
+    void return_specialization_from_other_type_temp() {
         Mock<SomeStruct> mock;
 
         When(Method(mock, returnRef)).Return<std::string>("something");
@@ -76,9 +94,17 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         When(Method(mock, returnRefMo)).Return<MoveOnly>(5);
         ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
         Verify(Method(mock, returnRefMo)).Once();
+
+        When(Method(mock, returnVal)).Return<std::string>("something");
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        Verify(Method(mock, returnVal)).Once();
+
+        When(Method(mock, returnValMo)).Return<MoveOnly>(5);
+        ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+        Verify(Method(mock, returnValMo)).Once();
     }
 
-    void return_ref_capture_from_other_type_temp() {
+    void return_capture_from_other_type_temp() {
         Mock<SomeStruct> mock;
 
         When(Method(mock, returnRef)).ReturnCapture("something");
@@ -88,54 +114,116 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         When(Method(mock, returnRefMo)).ReturnCapture(5);
         ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
         Verify(Method(mock, returnRefMo)).Once();
+
+        When(Method(mock, returnVal)).ReturnCapture("something");
+        ASSERT_EQUAL(mock.get().returnVal(), "something");
+        Verify(Method(mock, returnVal)).Once();
+
+        When(Method(mock, returnValMo)).ReturnCapture(5);
+        ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+        Verify(Method(mock, returnValMo)).Once();
     }
 
-    void return_ref_default_from_variable() {
-        std::string something = "something";
-        MoveOnly mo = 5;
+    void return_default_from_variable() {
         Mock<SomeStruct> mock;
 
-        When(Method(mock, returnRef)).Return(something);
-        something = "a different thing";
-        ASSERT_EQUAL(mock.get().returnRef(), "a different thing");
-        Verify(Method(mock, returnRef)).Once();
+        {
+            std::string something = "something";
+            MoveOnly mo = 5;
 
-        When(Method(mock, returnRefMo)).Return(mo);
-        mo.i = 10;
-        ASSERT_EQUAL(mock.get().returnRefMo().i, 10);
-        Verify(Method(mock, returnRefMo)).Once();
+            When(Method(mock, returnRef)).Return(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "a different thing");
+            Verify(Method(mock, returnRef)).Once();
+
+            When(Method(mock, returnRefMo)).Return(mo);
+            mo.i = 10;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 10);
+            Verify(Method(mock, returnRefMo)).Once();
+        }
+
+        {
+            std::string something = "something";
+            MoveOnly mo = 5;
+
+            When(Method(mock, returnVal)).Return(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            Verify(Method(mock, returnVal)).Once();
+
+            When(Method(mock, returnValMo)).Return(std::move(mo));
+            mo.i = 10;
+            ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+            Verify(Method(mock, returnValMo)).Once();
+        }
     }
 
-    void return_ref_specialization_from_variable() {
-        std::string something = "something";
-        MoveOnly mo = 5;
+    void return_specialization_from_variable() {
         Mock<SomeStruct> mock;
 
-        When(Method(mock, returnRef)).Return<std::string>(something);
-        something = "a different thing";
-        ASSERT_EQUAL(mock.get().returnRef(), "something");
-        Verify(Method(mock, returnRef)).Once();
+        {
+            std::string something = "something";
+            MoveOnly mo = 5;
 
-        When(Method(mock, returnRefMo)).Return<MoveOnly>(std::move(mo));
-        mo.i = 10;
-        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
-        Verify(Method(mock, returnRefMo)).Once();
+            When(Method(mock, returnRef)).Return<std::string>(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "something");
+            Verify(Method(mock, returnRef)).Once();
+
+            When(Method(mock, returnRefMo)).Return<MoveOnly>(std::move(mo));
+            mo.i = 10;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+            Verify(Method(mock, returnRefMo)).Once();
+        }
+
+        {
+            std::string something = "something";
+            MoveOnly mo = 5;
+
+            When(Method(mock, returnVal)).Return<std::string>(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            Verify(Method(mock, returnVal)).Once();
+
+            When(Method(mock, returnValMo)).Return<MoveOnly>(std::move(mo));
+            mo.i = 10;
+            ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+            Verify(Method(mock, returnValMo)).Once();
+        }
     }
 
-    void return_ref_capture_from_variable() {
-        std::string something = "something";
-        MoveOnly mo = 5;
+    void return_capture_from_variable() {
         Mock<SomeStruct> mock;
 
-        When(Method(mock, returnRef)).ReturnCapture(something);
-        something = "a different thing";
-        ASSERT_EQUAL(mock.get().returnRef(), "something");
-        Verify(Method(mock, returnRef)).Once();
+        {
+            std::string something = "something";
+            MoveOnly mo = 5;
 
-        When(Method(mock, returnRefMo)).ReturnCapture(std::move(mo));
-        mo.i = 10;
-        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
-        Verify(Method(mock, returnRefMo)).Once();
+            When(Method(mock, returnRef)).ReturnCapture(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "something");
+            Verify(Method(mock, returnRef)).Once();
+
+            When(Method(mock, returnRefMo)).ReturnCapture(std::move(mo));
+            mo.i = 10;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+            Verify(Method(mock, returnRefMo)).Once();
+        }
+
+        {
+            std::string something = "something";
+            MoveOnly mo = 5;
+
+            When(Method(mock, returnVal)).ReturnCapture(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            Verify(Method(mock, returnVal)).Once();
+
+            When(Method(mock, returnValMo)).ReturnCapture(std::move(mo));
+            mo.i = 10;
+            ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+            Verify(Method(mock, returnValMo)).Once();
+        }
     }
 
 } __ReturnTemplateSpecializationTests;

--- a/tests/return_template_specialization.cpp
+++ b/tests/return_template_specialization.cpp
@@ -1,0 +1,141 @@
+/*
+ * Copyright (c) 2014 Eran Pe'er.
+ *
+ * This program is made available under the terms of the MIT License.
+ *
+ * Created on Mar 10, 2014
+ */
+
+#include "tpunit++.hpp"
+#include "fakeit.hpp"
+
+using namespace fakeit;
+
+struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
+
+    ReturnTemplateSpecializationTests()
+        : tpunit::TestFixture(
+            TEST(ReturnTemplateSpecializationTests::return_ref_specialization_from_same_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_ref_capture_from_same_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_ref_specialization_from_other_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_ref_capture_from_other_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_ref_default_from_variable),
+            TEST(ReturnTemplateSpecializationTests::return_ref_specialization_from_variable),
+            TEST(ReturnTemplateSpecializationTests::return_ref_capture_from_variable)
+        ) {
+    }
+
+    struct MoveOnly {
+        int i = 0;
+        MoveOnly(int pi) : i{pi} {}
+        MoveOnly(const MoveOnly&) = delete;
+        MoveOnly(MoveOnly&&) = default;
+    };
+
+    struct SomeStruct {
+        virtual ~SomeStruct() = default;
+
+        virtual const std::string& returnRef() = 0;
+
+        virtual const MoveOnly& returnRefMo() = 0;
+
+        virtual std::string returnVal() = 0;
+    };
+
+    void return_ref_specialization_from_same_type_temp() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnRef)).Return<std::string>(std::string("something"));
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        Verify(Method(mock, returnRef)).Once();
+
+        When(Method(mock, returnRefMo)).Return<MoveOnly>(MoveOnly{5});
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        Verify(Method(mock, returnRefMo)).Once();
+    }
+
+    void return_ref_capture_from_same_type_temp() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnRef)).ReturnCapture(std::string("something"));
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        Verify(Method(mock, returnRef)).Once();
+
+        When(Method(mock, returnRefMo)).ReturnCapture(MoveOnly{5});
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        Verify(Method(mock, returnRefMo)).Once();
+    }
+
+    void return_ref_specialization_from_other_type_temp() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnRef)).Return<std::string>("something");
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        Verify(Method(mock, returnRef)).Once();
+
+        When(Method(mock, returnRefMo)).Return<MoveOnly>(5);
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        Verify(Method(mock, returnRefMo)).Once();
+    }
+
+    void return_ref_capture_from_other_type_temp() {
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnRef)).ReturnCapture("something");
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        Verify(Method(mock, returnRef)).Once();
+
+        When(Method(mock, returnRefMo)).ReturnCapture(5);
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        Verify(Method(mock, returnRefMo)).Once();
+    }
+
+    void return_ref_default_from_variable() {
+        std::string something = "something";
+        MoveOnly mo = 5;
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnRef)).Return(something);
+        something = "a different thing";
+        ASSERT_EQUAL(mock.get().returnRef(), "a different thing");
+        Verify(Method(mock, returnRef)).Once();
+
+        When(Method(mock, returnRefMo)).Return(mo);
+        mo.i = 10;
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 10);
+        Verify(Method(mock, returnRefMo)).Once();
+    }
+
+    void return_ref_specialization_from_variable() {
+        std::string something = "something";
+        MoveOnly mo = 5;
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnRef)).Return<std::string>(something);
+        something = "a different thing";
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        Verify(Method(mock, returnRef)).Once();
+
+        When(Method(mock, returnRefMo)).Return<MoveOnly>(std::move(mo));
+        mo.i = 10;
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        Verify(Method(mock, returnRefMo)).Once();
+    }
+
+    void return_ref_capture_from_variable() {
+        std::string something = "something";
+        MoveOnly mo = 5;
+        Mock<SomeStruct> mock;
+
+        When(Method(mock, returnRef)).ReturnCapture(something);
+        something = "a different thing";
+        ASSERT_EQUAL(mock.get().returnRef(), "something");
+        Verify(Method(mock, returnRef)).Once();
+
+        When(Method(mock, returnRefMo)).ReturnCapture(std::move(mo));
+        mo.i = 10;
+        ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+        Verify(Method(mock, returnRefMo)).Once();
+    }
+
+} __ReturnTemplateSpecializationTests;

--- a/tests/return_template_specialization.cpp
+++ b/tests/return_template_specialization.cpp
@@ -17,22 +17,28 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         : tpunit::TestFixture(
             TEST(ReturnTemplateSpecializationTests::return_default_from_same_type_temp),
             TEST(ReturnTemplateSpecializationTests::return_valspecialization_from_same_type_temp),
-            TEST(ReturnTemplateSpecializationTests::return_capture_from_same_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_valcapt_from_same_type_temp),
             TEST(ReturnTemplateSpecializationTests::return_default_from_other_type_temp),
             TEST(ReturnTemplateSpecializationTests::return_valspecialization_from_other_type_temp),
-            TEST(ReturnTemplateSpecializationTests::return_capture_from_other_type_temp),
-            TEST(ReturnTemplateSpecializationTests::return_default_from_variable),
-            TEST(ReturnTemplateSpecializationTests::return_valspecialization_from_variable),
-            TEST(ReturnTemplateSpecializationTests::return_capture_from_variable),
+            TEST(ReturnTemplateSpecializationTests::return_valcapt_from_other_type_temp),
+            TEST(ReturnTemplateSpecializationTests::return_default_from_same_type_variable),
+            TEST(ReturnTemplateSpecializationTests::return_valspecialization_from_same_type_variable),
+            TEST(ReturnTemplateSpecializationTests::return_valcapt_from_same_type_variable),
+            TEST(ReturnTemplateSpecializationTests::return_default_from_other_type_variable),
+            TEST(ReturnTemplateSpecializationTests::return_valspecialization_from_other_type_variable),
+            TEST(ReturnTemplateSpecializationTests::return_valcapt_from_other_type_variable),
             TEST(ReturnTemplateSpecializationTests::always_return_default_from_same_type_temp),
             TEST(ReturnTemplateSpecializationTests::always_return_valspecialization_from_same_type_temp),
-            TEST(ReturnTemplateSpecializationTests::always_return_capture_from_same_type_temp),
+            TEST(ReturnTemplateSpecializationTests::always_return_valcapt_from_same_type_temp),
             TEST(ReturnTemplateSpecializationTests::always_return_default_from_other_type_temp),
             TEST(ReturnTemplateSpecializationTests::always_return_valspecialization_from_other_type_temp),
-            TEST(ReturnTemplateSpecializationTests::always_return_capture_from_other_type_temp),
-            TEST(ReturnTemplateSpecializationTests::always_return_default_from_variable),
-            TEST(ReturnTemplateSpecializationTests::always_return_valspecialization_from_variable),
-            TEST(ReturnTemplateSpecializationTests::always_return_capture_from_variable)
+            TEST(ReturnTemplateSpecializationTests::always_return_valcapt_from_other_type_temp),
+            TEST(ReturnTemplateSpecializationTests::always_return_default_from_same_type_variable),
+            TEST(ReturnTemplateSpecializationTests::always_return_valspecialization_from_same_type_variable),
+            TEST(ReturnTemplateSpecializationTests::always_return_valcapt_from_same_type_variable),
+            TEST(ReturnTemplateSpecializationTests::always_return_default_from_other_type_variable),
+            TEST(ReturnTemplateSpecializationTests::always_return_valspecialization_from_other_type_variable),
+            TEST(ReturnTemplateSpecializationTests::always_return_valcapt_from_other_type_variable)
         ) {
     }
 
@@ -87,22 +93,22 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         Verify(Method(mock, returnValMo)).Once();
     }
 
-    void return_capture_from_same_type_temp() {
+    void return_valcapt_from_same_type_temp() {
         Mock<SomeStruct> mock;
 
-        When(Method(mock, returnRef)).ReturnCapture(std::string("something"));
+        When(Method(mock, returnRef)).ReturnValCapt(std::string("something"));
         ASSERT_EQUAL(mock.get().returnRef(), "something");
         Verify(Method(mock, returnRef)).Once();
 
-        When(Method(mock, returnRefMo)).ReturnCapture(MoveOnly{5});
+        When(Method(mock, returnRefMo)).ReturnValCapt(MoveOnly{5});
         ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
         Verify(Method(mock, returnRefMo)).Once();
 
-        When(Method(mock, returnVal)).ReturnCapture(std::string("something"));
+        When(Method(mock, returnVal)).ReturnValCapt(std::string("something"));
         ASSERT_EQUAL(mock.get().returnVal(), "something");
         Verify(Method(mock, returnVal)).Once();
 
-        When(Method(mock, returnValMo)).ReturnCapture(MoveOnly{5});
+        When(Method(mock, returnValMo)).ReturnValCapt(MoveOnly{5});
         ASSERT_EQUAL(mock.get().returnValMo().i, 5);
         Verify(Method(mock, returnValMo)).Once();
     }
@@ -139,27 +145,27 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         Verify(Method(mock, returnValMo)).Once();
     }
 
-    void return_capture_from_other_type_temp() {
+    void return_valcapt_from_other_type_temp() {
         Mock<SomeStruct> mock;
 
-        When(Method(mock, returnRef)).ReturnCapture("something");
+        When(Method(mock, returnRef)).ReturnValCapt("something");
         ASSERT_EQUAL(mock.get().returnRef(), "something");
         Verify(Method(mock, returnRef)).Once();
 
-        When(Method(mock, returnRefMo)).ReturnCapture(5);
+        When(Method(mock, returnRefMo)).ReturnValCapt(5);
         ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
         Verify(Method(mock, returnRefMo)).Once();
 
-        When(Method(mock, returnVal)).ReturnCapture("something");
+        When(Method(mock, returnVal)).ReturnValCapt("something");
         ASSERT_EQUAL(mock.get().returnVal(), "something");
         Verify(Method(mock, returnVal)).Once();
 
-        When(Method(mock, returnValMo)).ReturnCapture(5);
+        When(Method(mock, returnValMo)).ReturnValCapt(5);
         ASSERT_EQUAL(mock.get().returnValMo().i, 5);
         Verify(Method(mock, returnValMo)).Once();
     }
 
-    void return_default_from_variable() {
+    void return_default_from_same_type_variable() {
         Mock<SomeStruct> mock;
 
         {
@@ -193,7 +199,7 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         }
     }
 
-    void return_valspecialization_from_variable() {
+    void return_valspecialization_from_same_type_variable() {
         Mock<SomeStruct> mock;
 
         {
@@ -227,19 +233,19 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         }
     }
 
-    void return_capture_from_variable() {
+    void return_valcapt_from_same_type_variable() {
         Mock<SomeStruct> mock;
 
         {
             std::string something = "something";
             MoveOnly mo = 5;
 
-            When(Method(mock, returnRef)).ReturnCapture(something);
+            When(Method(mock, returnRef)).ReturnValCapt(something);
             something = "a different thing";
             ASSERT_EQUAL(mock.get().returnRef(), "something");
             Verify(Method(mock, returnRef)).Once();
 
-            When(Method(mock, returnRefMo)).ReturnCapture(std::move(mo));
+            When(Method(mock, returnRefMo)).ReturnValCapt(std::move(mo));
             mo.i = 10;
             ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
             Verify(Method(mock, returnRefMo)).Once();
@@ -249,13 +255,100 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
             std::string something = "something";
             MoveOnly mo = 5;
 
-            When(Method(mock, returnVal)).ReturnCapture(something);
+            When(Method(mock, returnVal)).ReturnValCapt(something);
             something = "a different thing";
             ASSERT_EQUAL(mock.get().returnVal(), "something");
             Verify(Method(mock, returnVal)).Once();
 
-            When(Method(mock, returnValMo)).ReturnCapture(std::move(mo));
+            When(Method(mock, returnValMo)).ReturnValCapt(std::move(mo));
             mo.i = 10;
+            ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+            Verify(Method(mock, returnValMo)).Once();
+        }
+    }
+
+    void return_default_from_other_type_variable() {
+        Mock<SomeStruct> mock;
+
+        {
+            const char* something = "something";
+            int num = 5;
+
+            When(Method(mock, returnVal)).Return(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            Verify(Method(mock, returnVal)).Once();
+
+            When(Method(mock, returnValMo)).Return(num);
+            num = 10;
+            ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+            Verify(Method(mock, returnValMo)).Once();
+        }
+    }
+
+    void return_valspecialization_from_other_type_variable() {
+        Mock<SomeStruct> mock;
+
+        {
+            const char* something = "something";
+            int num = 5;
+
+            When(Method(mock, returnRef)).Return<std::string>(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "something");
+            Verify(Method(mock, returnRef)).Once();
+
+            When(Method(mock, returnRefMo)).Return<MoveOnly>(num);
+            num = 10;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+            Verify(Method(mock, returnRefMo)).Once();
+        }
+
+        {
+            const char* something = "something";
+            int num = 5;
+
+            When(Method(mock, returnVal)).Return<std::string>(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            Verify(Method(mock, returnVal)).Once();
+
+            When(Method(mock, returnValMo)).Return<MoveOnly>(num);
+            num = 10;
+            ASSERT_EQUAL(mock.get().returnValMo().i, 5);
+            Verify(Method(mock, returnValMo)).Once();
+        }
+    }
+
+    void return_valcapt_from_other_type_variable() {
+        Mock<SomeStruct> mock;
+
+        {
+            const char* something = "something";
+            int num = 5;
+
+            When(Method(mock, returnRef)).ReturnValCapt(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "something");
+            Verify(Method(mock, returnRef)).Once();
+
+            When(Method(mock, returnRefMo)).ReturnValCapt(num);
+            num = 10;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+            Verify(Method(mock, returnRefMo)).Once();
+        }
+
+        {
+            const char* something = "something";
+            int num = 5;
+
+            When(Method(mock, returnVal)).ReturnValCapt(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            Verify(Method(mock, returnVal)).Once();
+
+            When(Method(mock, returnValMo)).ReturnValCapt(num);
+            num = 10;
             ASSERT_EQUAL(mock.get().returnValMo().i, 5);
             Verify(Method(mock, returnValMo)).Once();
         }
@@ -289,20 +382,20 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         Verify(Method(mock, returnVal)).Exactly(2);
     }
 
-    void always_return_capture_from_same_type_temp() {
+    void always_return_valcapt_from_same_type_temp() {
         Mock<SomeStruct> mock;
 
-        When(Method(mock, returnRef)).AlwaysReturnCapture(std::string("something"));
+        When(Method(mock, returnRef)).AlwaysReturnValCapt(std::string("something"));
         ASSERT_EQUAL(mock.get().returnRef(), "something");
         ASSERT_EQUAL(mock.get().returnRef(), "something");
         Verify(Method(mock, returnRef)).Exactly(2);
 
-        When(Method(mock, returnRefMo)).AlwaysReturnCapture(MoveOnly{5});
+        When(Method(mock, returnRefMo)).AlwaysReturnValCapt(MoveOnly{5});
         ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
         ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
         Verify(Method(mock, returnRefMo)).Exactly(2);
 
-        When(Method(mock, returnVal)).AlwaysReturnCapture(std::string("something"));
+        When(Method(mock, returnVal)).AlwaysReturnValCapt(std::string("something"));
         ASSERT_EQUAL(mock.get().returnVal(), "something");
         ASSERT_EQUAL(mock.get().returnVal(), "something");
         Verify(Method(mock, returnVal)).Exactly(2);
@@ -336,26 +429,26 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         Verify(Method(mock, returnVal)).Exactly(2);
     }
 
-    void always_return_capture_from_other_type_temp() {
+    void always_return_valcapt_from_other_type_temp() {
         Mock<SomeStruct> mock;
 
-        When(Method(mock, returnRef)).AlwaysReturnCapture("something");
+        When(Method(mock, returnRef)).AlwaysReturnValCapt("something");
         ASSERT_EQUAL(mock.get().returnRef(), "something");
         ASSERT_EQUAL(mock.get().returnRef(), "something");
         Verify(Method(mock, returnRef)).Exactly(2);
 
-        When(Method(mock, returnRefMo)).AlwaysReturnCapture(5);
+        When(Method(mock, returnRefMo)).AlwaysReturnValCapt(5);
         ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
         ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
         Verify(Method(mock, returnRefMo)).Exactly(2);
 
-        When(Method(mock, returnVal)).AlwaysReturnCapture("something");
+        When(Method(mock, returnVal)).AlwaysReturnValCapt("something");
         ASSERT_EQUAL(mock.get().returnVal(), "something");
         ASSERT_EQUAL(mock.get().returnVal(), "something");
         Verify(Method(mock, returnVal)).Exactly(2);
     }
 
-    void always_return_default_from_variable() {
+    void always_return_default_from_same_type_variable() {
         Mock<SomeStruct> mock;
 
         {
@@ -389,7 +482,7 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         }
     }
 
-    void always_return_valspecialization_from_variable() {
+    void always_return_valspecialization_from_same_type_variable() {
         Mock<SomeStruct> mock;
 
         {
@@ -423,21 +516,21 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         }
     }
 
-    void always_return_capture_from_variable() {
+    void always_return_valcapt_from_same_type_variable() {
         Mock<SomeStruct> mock;
 
         {
             std::string something = "something";
             MoveOnly mo = 5;
 
-            When(Method(mock, returnRef)).AlwaysReturnCapture(something);
+            When(Method(mock, returnRef)).AlwaysReturnValCapt(something);
             something = "a different thing";
             ASSERT_EQUAL(mock.get().returnRef(), "something");
             something = "another different thing";
             ASSERT_EQUAL(mock.get().returnRef(), "something");
             Verify(Method(mock, returnRef)).Exactly(2);
 
-            When(Method(mock, returnRefMo)).AlwaysReturnCapture(std::move(mo));
+            When(Method(mock, returnRefMo)).AlwaysReturnValCapt(std::move(mo));
             mo.i = 10;
             ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
             mo.i = 50;
@@ -448,7 +541,90 @@ struct ReturnTemplateSpecializationTests : tpunit::TestFixture {
         {
             std::string something = "something";
 
-            When(Method(mock, returnVal)).AlwaysReturnCapture(something);
+            When(Method(mock, returnVal)).AlwaysReturnValCapt(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            something = "another different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            Verify(Method(mock, returnVal)).Exactly(2);
+        }
+    }
+
+    void always_return_default_from_other_type_variable() {
+        Mock<SomeStruct> mock;
+
+        {
+            const char* something = "something";
+
+            When(Method(mock, returnVal)).AlwaysReturn(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            something = "another different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            Verify(Method(mock, returnVal)).Exactly(2);
+        }
+    }
+
+    void always_return_valspecialization_from_other_type_variable() {
+        Mock<SomeStruct> mock;
+
+        {
+            const char* something = "something";
+            int num = 5;
+
+            When(Method(mock, returnRef)).AlwaysReturn<std::string>(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "something");
+            something = "another different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "something");
+            Verify(Method(mock, returnRef)).Exactly(2);
+
+            When(Method(mock, returnRefMo)).AlwaysReturn<MoveOnly>(num);
+            num = 10;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+            num = 50;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+            Verify(Method(mock, returnRefMo)).Exactly(2);
+        }
+
+        {
+            const char* something = "something";
+
+            When(Method(mock, returnVal)).AlwaysReturn<std::string>(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            something = "another different thing";
+            ASSERT_EQUAL(mock.get().returnVal(), "something");
+            Verify(Method(mock, returnVal)).Exactly(2);
+        }
+    }
+
+    void always_return_valcapt_from_other_type_variable() {
+        Mock<SomeStruct> mock;
+
+        {
+            const char* something = "something";
+            int num = 5;
+
+            When(Method(mock, returnRef)).AlwaysReturnValCapt(something);
+            something = "a different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "something");
+            something = "another different thing";
+            ASSERT_EQUAL(mock.get().returnRef(), "something");
+            Verify(Method(mock, returnRef)).Exactly(2);
+
+            When(Method(mock, returnRefMo)).AlwaysReturnValCapt(num);
+            num = 10;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+            num = 50;
+            ASSERT_EQUAL(mock.get().returnRefMo().i, 5);
+            Verify(Method(mock, returnRefMo)).Exactly(2);
+        }
+
+        {
+            const char* something = "something";
+
+            When(Method(mock, returnVal)).AlwaysReturnValCapt(something);
             something = "a different thing";
             ASSERT_EQUAL(mock.get().returnVal(), "something");
             something = "another different thing";


### PR DESCRIPTION
Basically what's here: https://github.com/eranpeer/FakeIt/issues/337.

What this PR do:
- Reintroduce back the support for `.Return<type>(obj)` and `.Return<type&>(obj)` to not break to much code with the new update, they are deprecated and shouldn't be used.
- Add `ReturnValCapt` and `ReturnRefCapt` to force a capture either by value (move or copy) or by reference, independent of the return type of the mocked function.
- For a function returning `T&`, `ReturnValCapt(U{})` will store the original object if `U&` can be cast to `T&` (if `T` is a parent of `U`, for example) to avoid object slicing, otherwise a `T` will be constructed from the `U` passed by parameter and stored, to avoid creating a temporary (and returning a reference to it) when the mocked function is called.